### PR TITLE
Refactor… lots of things

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-CONFIG=examples/fosdem.yaml
+CONFIG=examples/imagesource.yaml
 
 builddir:
 	mkdir -p build

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-CONFIG=examples/imagesource.yaml
+CONFIG=examples/fosdem.yaml
 
 builddir:
 	mkdir -p build

--- a/cmd/fazantix/main.go
+++ b/cmd/fazantix/main.go
@@ -3,10 +3,16 @@ package main
 import (
 	"log"
 	"os"
+	"runtime"
 
 	"github.com/fosdem/fazantix/lib/config"
 	"github.com/fosdem/fazantix/lib/mixer"
 )
+
+func init() {
+	// The OpenGL stuff must be in one thread
+	runtime.LockOSThread()
+}
 
 func main() {
 	if len(os.Args) < 2 {

--- a/lib/api/api.go
+++ b/lib/api/api.go
@@ -71,6 +71,7 @@ func (a *Api) Serve() error {
 	if a.cfg.EnableProfiler {
 		a.mux.HandleFunc("/prof", a.profileCPU)
 	}
+	a.mux.HandleFunc("/api/kill", a.suicide)
 	a.mux.HandleFunc("/api/stats", a.stats)
 	a.mux.HandleFunc("/api/scene", a.handleScene)
 	a.mux.HandleFunc("/api/scene/{stage}/{scene}", a.handleScene)
@@ -127,6 +128,16 @@ type Stats struct {
 	Uptime             float64 `json:"uptime"`
 	FPS                int     `json:"fps"`
 	WsClients          int     `json:"ws_clients"`
+}
+
+func (a *Api) suicide(w http.ResponseWriter, _ *http.Request) {
+	log.Printf("shutting down as per api request")
+	a.theatre.ShutdownRequested = true
+	_, err := fmt.Fprintf(w, "\"ok\"\n")
+	if err != nil {
+		log.Printf("could not write response: %s\n", err.Error())
+		return
+	}
 }
 
 func (a *Api) stats(w http.ResponseWriter, _ *http.Request) {

--- a/lib/api/api.go
+++ b/lib/api/api.go
@@ -15,7 +15,7 @@ import (
 	"github.com/gorilla/websocket"
 
 	"github.com/fosdem/fazantix/lib/config"
-	"github.com/fosdem/fazantix/lib/rendering"
+	"github.com/fosdem/fazantix/lib/stats"
 	"github.com/fosdem/fazantix/lib/theatre"
 )
 
@@ -28,8 +28,8 @@ type Api struct {
 	mux     *http.ServeMux
 	cfg     *config.ApiCfg
 	theatre *theatre.Theatre
-	start   time.Time
-	FPS     int
+
+	Stats *stats.Stats
 
 	wsClients map[*websocket.Conn]bool
 }
@@ -63,16 +63,16 @@ func New(cfg *config.ApiCfg, t *theatre.Theatre) *Api {
 			}
 		}
 	})
+	a.Stats = stats.New()
 	return a
 }
 
 func (a *Api) Serve() error {
-	a.start = time.Now()
 	if a.cfg.EnableProfiler {
 		a.mux.HandleFunc("/prof", a.profileCPU)
 	}
 	a.mux.HandleFunc("/api/kill", a.suicide)
-	a.mux.HandleFunc("/api/stats", a.stats)
+	a.mux.HandleFunc("/api/stats", a.getStats)
 	a.mux.HandleFunc("/api/scene", a.handleScene)
 	a.mux.HandleFunc("/api/scene/{stage}/{scene}", a.handleScene)
 	a.mux.HandleFunc("/api/config", a.handleConfig)
@@ -122,14 +122,6 @@ func (a *Api) profileCPU(w http.ResponseWriter, _ *http.Request) {
 	pprof.StopCPUProfile()
 }
 
-type Stats struct {
-	TextureUpload      uint64  `json:"texture_upload"`
-	TextureUploadAvgGb float64 `json:"texture_upload_avg_gb"`
-	Uptime             float64 `json:"uptime"`
-	FPS                int     `json:"fps"`
-	WsClients          int     `json:"ws_clients"`
-}
-
 func (a *Api) suicide(w http.ResponseWriter, _ *http.Request) {
 	log.Printf("shutting down as per api request")
 	a.theatre.ShutdownRequested = true
@@ -140,18 +132,9 @@ func (a *Api) suicide(w http.ResponseWriter, _ *http.Request) {
 	}
 }
 
-func (a *Api) stats(w http.ResponseWriter, _ *http.Request) {
-	uptime := float64(time.Since(a.start).Nanoseconds()) / 1e9
-	stats := &Stats{
-		Uptime:             uptime,
-		TextureUpload:      rendering.TextureUploadCounter,
-		TextureUploadAvgGb: float64(rendering.TextureUploadCounter) / (uptime * 1024 * 1024 * 1024),
-		FPS:                a.FPS,
-		WsClients:          len(a.wsClients),
-	}
-
+func (a *Api) getStats(w http.ResponseWriter, _ *http.Request) {
 	encoder := json.NewEncoder(w)
-	err := encoder.Encode(stats)
+	err := encoder.Encode(a.Stats)
 	if err != nil {
 		http.Error(w, fmt.Sprintf("could encode stats: %s", err), http.StatusForbidden)
 		return
@@ -203,10 +186,13 @@ func (a *Api) handleWebsocket(w http.ResponseWriter, req *http.Request) {
 
 	go a.websocketWriter(ws)
 
+	a.Stats.WsClients = len(a.wsClients)
+
 	for {
 		_, msg, err := ws.ReadMessage()
 		if err != nil {
 			delete(a.wsClients, ws)
+			a.Stats.WsClients = len(a.wsClients)
 			break
 		}
 		fmt.Printf("Received: %s\n", msg)
@@ -225,15 +211,8 @@ func (a *Api) websocketWriter(ws *websocket.Conn) {
 	}()
 	timeout := 10 * time.Second
 	for range pingTicker.C {
-		uptime := float64(time.Since(a.start).Nanoseconds()) / 1e9
-		stats := &Stats{
-			Uptime:             uptime,
-			TextureUpload:      rendering.TextureUploadCounter,
-			TextureUploadAvgGb: float64(rendering.TextureUploadCounter) / (uptime * 1024 * 1024 * 1024),
-			FPS:                a.FPS,
-			WsClients:          len(a.wsClients),
-		}
-		packet, err := json.Marshal(stats)
+		packet, err := json.Marshal(a.Stats)
+
 		if err != nil {
 			return
 		}

--- a/lib/imgsource/imgsource.go
+++ b/lib/imgsource/imgsource.go
@@ -76,7 +76,7 @@ func (s *ImgSource) Start() bool {
 	s.frames.IsReady = true
 	s.frames.IsStill = true
 
-	frame := s.frames.GetBlankFrame()
+	frame := s.frames.GetFrameForWriting()
 	if frame == nil {
 		s.log("Image source dropped its one and only frame - this is probably a bug")
 		return false
@@ -84,9 +84,10 @@ func (s *ImgSource) Start() bool {
 	err := encdec.FrameFromImage(s.img, frame)
 	if err != nil {
 		s.log("Decode error: %s", err)
+		s.frames.FailedWriting(frame)
 		return false
 	}
-	s.frames.SendFrame(frame)
+	s.frames.FinishedWriting(frame)
 	return true
 }
 

--- a/lib/kbdctl/shortcut_keys.go
+++ b/lib/kbdctl/shortcut_keys.go
@@ -14,6 +14,10 @@ func SetupShortcutKeys(theatre *theatre.Theatre, ws *windowsink.WindowSink) {
 	ws.Window.SetKeyCallback(keyCallback(theatre, ws.Frames().Name))
 }
 
+func Poll() {
+	glfw.PollEvents()
+}
+
 func keyCallback(theatre *theatre.Theatre, stageName string) func(w *glfw.Window, key glfw.Key, scancode int, action glfw.Action, mods glfw.ModifierKey) {
 	names := make([]string, len(theatre.Scenes))
 	copy(names, slices.Sorted(maps.Keys(theatre.Scenes)))

--- a/lib/kbdctl/shortcut_keys.go
+++ b/lib/kbdctl/shortcut_keys.go
@@ -28,7 +28,7 @@ func keyCallback(theatre *theatre.Theatre, stageName string) func(w *glfw.Window
 				mods&glfw.ModControl != 0 &&
 				mods&glfw.ModShift != 0 {
 				log.Println("told to quit, exiting")
-				w.SetShouldClose(true)
+				theatre.ShutdownRequested = true
 			}
 		}
 		if action == glfw.Press {

--- a/lib/layer/framefwd.go
+++ b/lib/layer/framefwd.go
@@ -48,7 +48,7 @@ func (f *FrameForwarder) FinishedReading(frame *encdec.Frame) {
 	// TODO: implement
 }
 
-func (f *FrameForwarder) SendFrame(frame *encdec.Frame) {
+func (f *FrameForwarder) FinishedWriting(frame *encdec.Frame) {
 	oldLastFrame := f.lastFrame
 	f.lastFrame = frame
 	f.FrameAge = 0
@@ -58,7 +58,11 @@ func (f *FrameForwarder) SendFrame(frame *encdec.Frame) {
 	}
 }
 
-func (f *FrameForwarder) GetBlankFrame() *encdec.Frame {
+func (f *FrameForwarder) FailedWriting(frame *encdec.Frame) {
+	f.recycleFrame(frame)
+}
+
+func (f *FrameForwarder) GetFrameForWriting() *encdec.Frame {
 	f.Lock()
 	defer f.Unlock()
 

--- a/lib/layer/layer.go
+++ b/lib/layer/layer.go
@@ -39,16 +39,6 @@ type LayerState struct {
 	Opacity float32
 }
 
-type Source interface {
-	Frames() *FrameForwarder
-	Start() bool
-}
-
-type Sink interface {
-	Frames() *FrameForwarder
-	Start() bool
-}
-
 func New(src Source, width int, height int) *Layer {
 	s := &Layer{}
 	s.Size = Coordinate{X: 1.0, Y: 1.0}

--- a/lib/layer/source.go
+++ b/lib/layer/source.go
@@ -1,0 +1,6 @@
+package layer
+
+type Source interface {
+	Frames() *FrameForwarder
+	Start() bool
+}

--- a/lib/layer/stage.go
+++ b/lib/layer/stage.go
@@ -1,0 +1,25 @@
+package layer
+
+type Stage struct {
+	Layers       []*Layer
+	HFlip        bool
+	VFlip        bool
+	Sink         Sink
+	DefaultScene string
+}
+
+type Sink interface {
+	Frames() *FrameForwarder
+	Start() bool
+}
+
+func (s *Stage) StageData() uint32 {
+	data := uint32(0)
+	if s.HFlip {
+		data += 1
+	}
+	if s.VFlip {
+		data += 2
+	}
+	return data
+}

--- a/lib/mixer/mixer.go
+++ b/lib/mixer/mixer.go
@@ -57,7 +57,7 @@ func MakeWindowAndMix(cfg *config.Config) {
 	layers := windowStage.Layers
 	numLayers := int32(len(layers))
 
-	glvars := rendering.AllocateGLVars(program, numLayers)
+	glvars := rendering.NewGLVars(program, numLayers)
 
 	// Create extra framebuffers as rendertargets
 	nonWindowStages := theatre.NonWindowStageList
@@ -74,7 +74,7 @@ func MakeWindowAndMix(cfg *config.Config) {
 		}
 	}
 
-	gl.ClearColor(1.0, 0.0, 0.0, 1.0)
+	glvars.Start()
 
 	frameCounter := 0
 	frameTimer := time.Now()

--- a/lib/mixer/mixer.go
+++ b/lib/mixer/mixer.go
@@ -81,10 +81,6 @@ func MakeWindowAndMix(cfg *config.Config) {
 	deltaTimer := time.Now()
 	firstFrame := true
 	for !windowSink.Window.ShouldClose() {
-		gl.BindFramebuffer(gl.FRAMEBUFFER, 0)
-		gl.Viewport(0, 0, int32(windowStage.Sink.Frames().Width), int32(windowStage.Sink.Frames().Height))
-		gl.Clear(gl.COLOR_BUFFER_BIT)
-
 		// Render
 		gl.UseProgram(program)
 
@@ -113,14 +109,12 @@ func MakeWindowAndMix(cfg *config.Config) {
 		// push vars common for all stages
 		glvars.PushCommonVars()
 
+		gl.BindFramebuffer(gl.FRAMEBUFFER, 0)
+		gl.Viewport(0, 0, int32(windowStage.Sink.Frames().Width), int32(windowStage.Sink.Frames().Height))
+		gl.Clear(gl.COLOR_BUFFER_BIT)
+
 		// push vars related to the window stage
-		for i := range numLayers {
-			glvars.LayerPos[(i*4)+0] = layers[i].Position.X
-			glvars.LayerPos[(i*4)+1] = layers[i].Position.Y
-			glvars.LayerPos[(i*4)+2] = layers[i].Size.X
-			glvars.LayerPos[(i*4)+3] = layers[i].Size.Y
-			glvars.LayerData[(i*4)+0] = layers[i].Opacity
-		}
+		glvars.ReadLayers(layers)
 		glvars.StageData = windowStage.StageData()
 		glvars.DrawStage()
 
@@ -133,13 +127,7 @@ func MakeWindowAndMix(cfg *config.Config) {
 			layers = stage.Layers
 
 			// push vars related to this non-window stage
-			for i := range numLayers {
-				glvars.LayerPos[(i*4)+0] = layers[i].Position.X
-				glvars.LayerPos[(i*4)+1] = layers[i].Position.Y
-				glvars.LayerPos[(i*4)+2] = layers[i].Size.X
-				glvars.LayerPos[(i*4)+3] = layers[i].Size.Y
-				glvars.LayerData[(i*4)+0] = layers[i].Opacity
-			}
+			glvars.ReadLayers(layers)
 			glvars.StageData = stage.StageData()
 			glvars.DrawStage()
 

--- a/lib/mixer/mixer.go
+++ b/lib/mixer/mixer.go
@@ -115,7 +115,6 @@ func MakeWindowAndMix(cfg *config.Config) {
 			rendering.SendFrameToGPU(frame, layers[i].Frames().TextureIDs, int(i))
 			layers[i].Frames().FinishedReading(frame)
 		}
-		theatre.Animate(float32(dt.Nanoseconds()) * 1e-9)
 		gl.Uniform4fv(glvars.LayerDataUniform, numLayers, &glvars.LayerData[0])
 		gl.Uniform4fv(glvars.LayerPosUniform, numLayers, &glvars.LayerPos[0])
 
@@ -146,6 +145,7 @@ func MakeWindowAndMix(cfg *config.Config) {
 		}
 
 		// Maintenance
+		theatre.Animate(float32(dt.Nanoseconds()) * 1e-9)
 		windowSink.Window.SwapBuffers()
 		frameCounter++
 		if time.Since(frameTimer) > 1*time.Second {

--- a/lib/mixer/mixer.go
+++ b/lib/mixer/mixer.go
@@ -13,7 +13,6 @@ import (
 	"github.com/fosdem/fazantix/lib/theatre"
 	"github.com/fosdem/fazantix/lib/utils"
 	"github.com/fosdem/fazantix/lib/windowsink"
-	"github.com/go-gl/glfw/v3.3/glfw"
 )
 
 func MakeWindowAndMix(cfg *config.Config) {
@@ -81,6 +80,6 @@ func MakeWindowAndMix(cfg *config.Config) {
 			frameCounter = 0
 			frameTimer = time.Now()
 		}
-		glfw.PollEvents()
+		kbdctl.Poll()
 	}
 }

--- a/lib/mixer/mixer.go
+++ b/lib/mixer/mixer.go
@@ -43,10 +43,7 @@ func MakeWindowAndMix(cfg *config.Config) {
 		log.Fatalf("could not init GL program: %s", err)
 	}
 
-	layers := windowStage.Layers
-	numLayers := int32(len(layers))
-
-	glvars := rendering.NewGLVars(program, numLayers)
+	glvars := rendering.NewGLVars(program, int32(len(theatre.SourceList)))
 
 	// Create extra framebuffers as rendertargets
 	nonWindowStages := theatre.NonWindowStageList
@@ -71,8 +68,6 @@ func MakeWindowAndMix(cfg *config.Config) {
 	for !windowSink.Window.ShouldClose() {
 		glvars.StartFrame()
 		dt := deltaTimer.Next()
-
-		layers = windowStage.Layers
 
 		rendering.SendFramesToGPU(theatre.SourceList, dt)
 

--- a/lib/mixer/mixer.go
+++ b/lib/mixer/mixer.go
@@ -2,7 +2,6 @@ package mixer
 
 import (
 	"log"
-	"time"
 
 	"github.com/fosdem/fazantix/lib/api"
 	"github.com/fosdem/fazantix/lib/config"
@@ -58,8 +57,6 @@ func MakeWindowAndMix(cfg *config.Config) {
 
 	glvars.Start()
 
-	frameCounter := 0
-	frameTimer := time.Now()
 	var deltaTimer utils.DeltaTimer
 	for !theatre.ShutdownRequested {
 		glvars.StartFrame()
@@ -85,14 +82,7 @@ func MakeWindowAndMix(cfg *config.Config) {
 
 		// Maintenance
 		theatre.Animate(float32(dt.Nanoseconds()) * 1e-9)
-		frameCounter++
-		if time.Since(frameTimer) > 1*time.Second {
-			if api != nil {
-				api.FPS = frameCounter
-			}
-			frameCounter = 0
-			frameTimer = time.Now()
-		}
+		api.Stats.Update()
 		kbdctl.Poll()
 	}
 }

--- a/lib/mixer/mixer.go
+++ b/lib/mixer/mixer.go
@@ -111,7 +111,7 @@ func MakeWindowAndMix(cfg *config.Config) {
 		}
 
 		// push vars common for all stages
-		gl.Uniform1iv(glvars.TexUniform, glvars.NumTextures, &glvars.Textures[0])
+		glvars.PushCommonVars()
 
 		// push vars related to the window stage
 		for i := range numLayers {
@@ -121,12 +121,8 @@ func MakeWindowAndMix(cfg *config.Config) {
 			glvars.LayerPos[(i*4)+3] = layers[i].Size.Y
 			glvars.LayerData[(i*4)+0] = layers[i].Opacity
 		}
-		gl.Uniform1ui(glvars.StageDataUniform, windowStage.StageData())
-		gl.Uniform4fv(glvars.LayerDataUniform, numLayers, &glvars.LayerData[0])
-		gl.Uniform4fv(glvars.LayerPosUniform, numLayers, &glvars.LayerPos[0])
-
-		// draw vertices on the window stage
-		gl.DrawArrays(gl.TRIANGLES, 0, 2*3)
+		glvars.StageData = windowStage.StageData()
+		glvars.DrawStage()
 
 		for _, stage := range nonWindowStages {
 			// Switch to the framebuffer connected to the window
@@ -144,12 +140,8 @@ func MakeWindowAndMix(cfg *config.Config) {
 				glvars.LayerPos[(i*4)+3] = layers[i].Size.Y
 				glvars.LayerData[(i*4)+0] = layers[i].Opacity
 			}
-			gl.Uniform1ui(glvars.StageDataUniform, stage.StageData())
-			gl.Uniform4fv(glvars.LayerDataUniform, numLayers, &glvars.LayerData[0])
-			gl.Uniform4fv(glvars.LayerPosUniform, numLayers, &glvars.LayerPos[0])
-
-			// draw vertices on this non-window stage
-			gl.DrawArrays(gl.TRIANGLES, 0, 2*3)
+			glvars.StageData = stage.StageData()
+			glvars.DrawStage()
 
 			frame := frames.GetBlankFrame()
 			gl.ReadPixels(0, 0, int32(frames.Width), int32(frames.Height), gl.RGB, gl.UNSIGNED_BYTE, gl.Ptr(frame.Data))

--- a/lib/mixer/mixer.go
+++ b/lib/mixer/mixer.go
@@ -13,7 +13,6 @@ import (
 	"github.com/fosdem/fazantix/lib/theatre"
 	"github.com/fosdem/fazantix/lib/utils"
 	"github.com/fosdem/fazantix/lib/windowsink"
-	"github.com/go-gl/gl/v4.1-core/gl"
 	"github.com/go-gl/glfw/v3.3/glfw"
 )
 
@@ -68,11 +67,7 @@ func MakeWindowAndMix(cfg *config.Config) {
 
 		for _, stage := range nonWindowStages {
 			glvars.DrawStage(stage)
-
-			frames := stage.Sink.Frames()
-			frame := frames.GetBlankFrame()
-			gl.ReadPixels(0, 0, int32(frames.Width), int32(frames.Height), gl.RGB, gl.UNSIGNED_BYTE, gl.Ptr(frame.Data))
-			frames.SendFrame(frame)
+			rendering.GetFrameFromGPUInto(stage.Sink)
 		}
 
 		// Maintenance

--- a/lib/mixer/mixer.go
+++ b/lib/mixer/mixer.go
@@ -53,13 +53,6 @@ func MakeWindowAndMix(cfg *config.Config) {
 		rendering.UseAsFramebuffer(stage.Sink.Frames())
 	}
 
-	for name, stage := range theatre.Stages {
-		err := theatre.SetScene(name, stage.DefaultScene)
-		if err != nil {
-			log.Fatalf("Could not apply default scene: %s", err)
-		}
-	}
-
 	glvars.Start()
 
 	frameCounter := 0

--- a/lib/mixer/mixer.go
+++ b/lib/mixer/mixer.go
@@ -2,7 +2,6 @@ package mixer
 
 import (
 	"log"
-	"runtime"
 	"time"
 
 	"github.com/fosdem/fazantix/lib/api"
@@ -17,11 +16,6 @@ import (
 	"github.com/go-gl/gl/v4.1-core/gl"
 	"github.com/go-gl/glfw/v3.3/glfw"
 )
-
-func init() {
-	// The OpenGL stuff must be in one thread
-	runtime.LockOSThread()
-}
 
 func initGL() {
 	if err := gl.Init(); err != nil {

--- a/lib/mixer/mixer.go
+++ b/lib/mixer/mixer.go
@@ -56,7 +56,7 @@ func MakeWindowAndMix(cfg *config.Config) {
 	frameCounter := 0
 	frameTimer := time.Now()
 	var deltaTimer utils.DeltaTimer
-	for !windowSink.Window.ShouldClose() {
+	for !theatre.ShutdownRequested {
 		glvars.StartFrame()
 		dt := deltaTimer.Next()
 

--- a/lib/mixer/mixer.go
+++ b/lib/mixer/mixer.go
@@ -17,15 +17,6 @@ import (
 	"github.com/go-gl/glfw/v3.3/glfw"
 )
 
-func initGL() {
-	if err := gl.Init(); err != nil {
-		panic(err)
-	}
-
-	version := gl.GoStr(gl.GetString(gl.VERSION))
-	log.Printf("OpenGL version '%s'", version)
-}
-
 func MakeWindowAndMix(cfg *config.Config) {
 	alloc := &encdec.DumbFrameAllocator{}
 
@@ -34,7 +25,10 @@ func MakeWindowAndMix(cfg *config.Config) {
 		log.Fatalf("could not build theatre: %s", err)
 	}
 
-	initGL()
+	err = rendering.Init()
+	if err != nil {
+		log.Fatalf("could not initialise renderer: %s", err)
+	}
 	// assume exactly one window stage for now
 	windowStage := theatre.GetTheSingleWindowStage()
 	windowSink := windowStage.Sink.(*windowsink.WindowSink)

--- a/lib/mixer/mixer.go
+++ b/lib/mixer/mixer.go
@@ -109,28 +109,12 @@ func MakeWindowAndMix(cfg *config.Config) {
 		// push vars common for all stages
 		glvars.PushCommonVars()
 
-		gl.BindFramebuffer(gl.FRAMEBUFFER, 0)
-		gl.Viewport(0, 0, int32(windowStage.Sink.Frames().Width), int32(windowStage.Sink.Frames().Height))
-		gl.Clear(gl.COLOR_BUFFER_BIT)
-
-		// push vars related to the window stage
-		glvars.ReadLayers(layers)
-		glvars.StageData = windowStage.StageData()
-		glvars.DrawStage()
+		glvars.DrawStage(windowStage)
 
 		for _, stage := range nonWindowStages {
-			// Switch to the framebuffer connected to the window
+			glvars.DrawStage(stage)
+
 			frames := stage.Sink.Frames()
-			gl.BindFramebuffer(gl.FRAMEBUFFER, frames.FramebufferID)
-			gl.Viewport(0, 0, int32(frames.Width), int32(frames.Height))
-			gl.Clear(gl.COLOR_BUFFER_BIT)
-			layers = stage.Layers
-
-			// push vars related to this non-window stage
-			glvars.ReadLayers(layers)
-			glvars.StageData = stage.StageData()
-			glvars.DrawStage()
-
 			frame := frames.GetBlankFrame()
 			gl.ReadPixels(0, 0, int32(frames.Width), int32(frames.Height), gl.RGB, gl.UNSIGNED_BYTE, gl.Ptr(frame.Data))
 			frames.SendFrame(frame)

--- a/lib/mixer/mixer.go
+++ b/lib/mixer/mixer.go
@@ -81,10 +81,7 @@ func MakeWindowAndMix(cfg *config.Config) {
 	deltaTimer := time.Now()
 	firstFrame := true
 	for !windowSink.Window.ShouldClose() {
-		// Render
-		gl.UseProgram(program)
-
-		gl.BindVertexArray(glvars.VAO)
+		glvars.StartFrame()
 
 		layers = windowStage.Layers
 
@@ -105,9 +102,6 @@ func MakeWindowAndMix(cfg *config.Config) {
 			rendering.SendFrameToGPU(frame, layers[i].Frames().TextureIDs, int(i))
 			layers[i].Frames().FinishedReading(frame)
 		}
-
-		// push vars common for all stages
-		glvars.PushCommonVars()
 
 		glvars.DrawStage(windowStage)
 

--- a/lib/mixer/mixer.go
+++ b/lib/mixer/mixer.go
@@ -38,6 +38,15 @@ func MakeWindowAndMix(cfg *config.Config) {
 
 	glvars := rendering.NewGLVars(program, int32(len(theatre.SourceList)))
 
+	if len(theatre.WindowSinkList) > 1 {
+		log.Fatalf("multiple window sinks are not supported yet")
+		// TODO: figure out how to share the stuff managed by glvars between windows
+	}
+	if len(theatre.WindowSinkList) < 1 {
+		log.Fatalf("usage without a window sink is not supported yet")
+		// TODO: figure out how to make a GL context without a window
+	}
+
 	for _, sink := range theatre.WindowSinkList {
 		kbdctl.SetupShortcutKeys(theatre, sink)
 	}

--- a/lib/rendering/frame_transport.go
+++ b/lib/rendering/frame_transport.go
@@ -1,0 +1,49 @@
+package rendering
+
+import (
+	"time"
+
+	"github.com/fosdem/fazantix/lib/encdec"
+	"github.com/fosdem/fazantix/lib/layer"
+	"github.com/go-gl/gl/v4.1-core/gl"
+)
+
+func SendFrameToGPU(frame *encdec.Frame, textureIDs [3]uint32, offset int) {
+	channelType := uint32(gl.RED)
+	if frame.Type == encdec.RGBAFrames {
+		channelType = gl.RGBA
+	}
+
+	for j := 0; j < frame.NumTextures; j++ {
+		dataPtr, w, h := frame.Texture(j)
+		SendTextureToGPU(
+			textureIDs[j], offset*3+j,
+			w, h, channelType,
+			dataPtr,
+		)
+	}
+}
+
+type ThingWithFrames interface {
+	Frames() *layer.FrameForwarder
+}
+
+func SendFramesToGPU[F ThingWithFrames](from []F, dt time.Duration) {
+	isFirstFrame := (dt == 0)
+
+	for i, thing := range from {
+		frames := thing.Frames()
+
+		frames.Age(dt)
+		if frames.IsStill && !isFirstFrame {
+			continue
+		}
+
+		frame := frames.GetFrameForReading()
+		if frame == nil {
+			continue
+		}
+		SendFrameToGPU(frame, frames.TextureIDs, int(i))
+		frames.FinishedReading(frame)
+	}
+}

--- a/lib/rendering/gl_vars.go
+++ b/lib/rendering/gl_vars.go
@@ -9,8 +9,10 @@ const f32 = 4
 type GLVars struct {
 	LayerPos  []float32
 	LayerData []float32
+	StageData uint32
 
 	NumTextures int32
+	NumLayers   int32
 
 	// GL IDs
 	VAO              uint32
@@ -24,6 +26,8 @@ type GLVars struct {
 
 func AllocateGLVars(program uint32, numLayers int32) *GLVars {
 	g := &GLVars{}
+
+	g.NumLayers = numLayers
 
 	vertices := []float32{
 		//  X, Y,  U, V
@@ -75,4 +79,17 @@ func AllocateGLVars(program uint32, numLayers int32) *GLVars {
 	gl.Uniform1iv(g.TexUniform, g.NumTextures, &g.Textures[0])
 
 	return g
+}
+
+func (g *GLVars) PushCommonVars() {
+	gl.Uniform1iv(g.TexUniform, g.NumTextures, &g.Textures[0])
+}
+
+func (g *GLVars) DrawStage() {
+	gl.Uniform1ui(g.StageDataUniform, g.StageData)
+	gl.Uniform4fv(g.LayerDataUniform, g.NumLayers, &g.LayerData[0])
+	gl.Uniform4fv(g.LayerPosUniform, g.NumLayers, &g.LayerPos[0])
+
+	// draw vertices on the window stage
+	gl.DrawArrays(gl.TRIANGLES, 0, 2*3)
 }

--- a/lib/rendering/gl_vars.go
+++ b/lib/rendering/gl_vars.go
@@ -96,11 +96,24 @@ func (g *GLVars) ReadLayers(layers []*layer.Layer) {
 	}
 }
 
-func (g *GLVars) DrawStage() {
+func (g *GLVars) PushStageVars() {
 	gl.Uniform1ui(g.StageDataUniform, g.StageData)
 	gl.Uniform4fv(g.LayerDataUniform, g.NumLayers, &g.LayerData[0])
 	gl.Uniform4fv(g.LayerPosUniform, g.NumLayers, &g.LayerPos[0])
 
 	// draw vertices on the window stage
 	gl.DrawArrays(gl.TRIANGLES, 0, 2*3)
+}
+
+func (g *GLVars) DrawStage(stage *layer.Stage) {
+	frames := stage.Sink.Frames()
+
+	gl.BindFramebuffer(gl.FRAMEBUFFER, 0)
+	gl.Viewport(0, 0, int32(frames.Width), int32(frames.Height))
+	gl.Clear(gl.COLOR_BUFFER_BIT)
+
+	// push vars related to the window stage
+	g.ReadLayers(stage.Layers)
+	g.StageData = stage.StageData()
+	g.PushStageVars()
 }

--- a/lib/rendering/gl_vars.go
+++ b/lib/rendering/gl_vars.go
@@ -108,7 +108,7 @@ func (g *GLVars) PushStageVars() {
 func (g *GLVars) DrawStage(stage *layer.Stage) {
 	frames := stage.Sink.Frames()
 
-	gl.BindFramebuffer(gl.FRAMEBUFFER, 0)
+	gl.BindFramebuffer(gl.FRAMEBUFFER, frames.FramebufferID)
 	gl.Viewport(0, 0, int32(frames.Width), int32(frames.Height))
 	gl.Clear(gl.COLOR_BUFFER_BIT)
 

--- a/lib/rendering/gl_vars.go
+++ b/lib/rendering/gl_vars.go
@@ -1,0 +1,78 @@
+package rendering
+
+import (
+	"github.com/go-gl/gl/v4.1-core/gl"
+)
+
+const f32 = 4
+
+type GLVars struct {
+	LayerPos  []float32
+	LayerData []float32
+
+	NumTextures int32
+
+	// GL IDs
+	VAO              uint32
+	VBO              uint32
+	Textures         []int32
+	LayerDataUniform int32
+	LayerPosUniform  int32
+	StageDataUniform int32
+	TexUniform       int32
+}
+
+func AllocateGLVars(program uint32, numLayers int32) *GLVars {
+	g := &GLVars{}
+
+	vertices := []float32{
+		//  X, Y,  U, V
+		-1.0, -1.0, 0.0, 1.0,
+		+1.0, -1.0, 1.0, 1.0,
+		+1.0, +1.0, 1.0, 0.0,
+
+		-1.0, -1.0, 0.0, 1.0,
+		+1.0, +1.0, 1.0, 0.0,
+		-1.0, +1.0, 0.0, 0.0,
+	}
+
+	// Configure the vertex data
+	gl.GenVertexArrays(1, &g.VAO)
+	gl.BindVertexArray(g.VAO)
+
+	gl.GenBuffers(1, &g.VBO)
+	gl.BindBuffer(gl.ARRAY_BUFFER, g.VBO)
+	gl.BufferData(gl.ARRAY_BUFFER, len(vertices)*f32, gl.Ptr(vertices), gl.STATIC_DRAW)
+
+	stride := int32(4 * f32)
+
+	vertAttrib := uint32(gl.GetAttribLocation(program, gl.Str("position\x00")))
+	gl.EnableVertexAttribArray(vertAttrib)
+	gl.VertexAttribPointerWithOffset(vertAttrib, 2, gl.FLOAT, false, stride, 0)
+
+	texCoordAttrib := uint32(gl.GetAttribLocation(program, gl.Str("uv\x00")))
+	gl.EnableVertexAttribArray(texCoordAttrib)
+	gl.VertexAttribPointerWithOffset(texCoordAttrib, 2, gl.FLOAT, false, stride, 2*f32)
+
+	g.LayerPos = make([]float32, numLayers*4)
+	g.LayerPosUniform = gl.GetUniformLocation(program, gl.Str("layerPosition\x00"))
+	gl.Uniform4fv(g.LayerPosUniform, numLayers, &g.LayerPos[0])
+
+	g.LayerData = make([]float32, numLayers*4)
+	g.LayerDataUniform = gl.GetUniformLocation(program, gl.Str("layerData\x00"))
+	gl.Uniform4fv(g.LayerDataUniform, numLayers, &g.LayerData[0])
+
+	g.StageDataUniform = gl.GetUniformLocation(program, gl.Str("stageData\x00"))
+	gl.Uniform1ui(g.StageDataUniform, 0)
+
+	// Allocate 3 textures for every layer in case of planar YUV
+	g.NumTextures = numLayers * 3
+	g.Textures = make([]int32, g.NumTextures)
+	for i := range g.NumTextures {
+		g.Textures[i] = int32(i)
+	}
+	g.TexUniform = gl.GetUniformLocation(program, gl.Str("tex\x00"))
+	gl.Uniform1iv(g.TexUniform, g.NumTextures, &g.Textures[0])
+
+	return g
+}

--- a/lib/rendering/gl_vars.go
+++ b/lib/rendering/gl_vars.go
@@ -1,6 +1,7 @@
 package rendering
 
 import (
+	"github.com/fosdem/fazantix/lib/layer"
 	"github.com/go-gl/gl/v4.1-core/gl"
 )
 
@@ -83,6 +84,16 @@ func AllocateGLVars(program uint32, numLayers int32) *GLVars {
 
 func (g *GLVars) PushCommonVars() {
 	gl.Uniform1iv(g.TexUniform, g.NumTextures, &g.Textures[0])
+}
+
+func (g *GLVars) ReadLayers(layers []*layer.Layer) {
+	for i := range g.NumLayers {
+		g.LayerPos[(i*4)+0] = layers[i].Position.X
+		g.LayerPos[(i*4)+1] = layers[i].Position.Y
+		g.LayerPos[(i*4)+2] = layers[i].Size.X
+		g.LayerPos[(i*4)+3] = layers[i].Size.Y
+		g.LayerData[(i*4)+0] = layers[i].Opacity
+	}
 }
 
 func (g *GLVars) DrawStage() {

--- a/lib/rendering/init.go
+++ b/lib/rendering/init.go
@@ -1,0 +1,20 @@
+package rendering
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/go-gl/gl/v4.1-core/gl"
+)
+
+func Init() error {
+	err := gl.Init()
+	if err != nil {
+		return fmt.Errorf("could not initialise OpenGL context: %w", err)
+	}
+
+	version := gl.GoStr(gl.GetString(gl.VERSION))
+	log.Printf("OpenGL version '%s'", version)
+
+	return nil
+}

--- a/lib/rendering/textures.go
+++ b/lib/rendering/textures.go
@@ -145,19 +145,3 @@ func SendTextureToGPU(texID uint32, offset int, w int, h int, channelType uint32
 	)
 	TextureUploadCounter += uint64(len(data))
 }
-
-func SendFrameToGPU(frame *encdec.Frame, textureIDs [3]uint32, offset int) {
-	channelType := uint32(gl.RED)
-	if frame.Type == encdec.RGBAFrames {
-		channelType = gl.RGBA
-	}
-
-	for j := 0; j < frame.NumTextures; j++ {
-		dataPtr, w, h := frame.Texture(j)
-		SendTextureToGPU(
-			textureIDs[j], offset*3+j,
-			w, h, channelType,
-			dataPtr,
-		)
-	}
-}

--- a/lib/stats/stats.go
+++ b/lib/stats/stats.go
@@ -1,0 +1,39 @@
+package stats
+
+import (
+	"time"
+
+	"github.com/fosdem/fazantix/lib/rendering"
+)
+
+type Stats struct {
+	TextureUpload      uint64  `json:"texture_upload"`
+	TextureUploadAvgGb float64 `json:"texture_upload_avg_gb"`
+	Uptime             float64 `json:"uptime"`
+	FPS                uint64  `json:"fps"`
+	WsClients          int     `json:"ws_clients"`
+
+	frameCounter uint64
+	frameTimer   time.Time
+	start        time.Time
+}
+
+func New() *Stats {
+	s := &Stats{}
+	s.start = time.Now()
+	return s
+}
+
+func (s *Stats) Update() {
+	s.frameCounter++
+	if time.Since(s.frameTimer) > 1*time.Second {
+		s.frameTimer = time.Now()
+		s.FPS = s.frameCounter
+		s.frameCounter = 0
+		s.frameTimer = time.Now()
+	}
+
+	s.Uptime = float64(time.Since(s.start).Nanoseconds()) / 1e9
+	s.TextureUpload = rendering.TextureUploadCounter
+	s.TextureUploadAvgGb = float64(s.TextureUpload) / (s.Uptime * 1024 * 1024 * 1024)
+}

--- a/lib/theatre/theatre.go
+++ b/lib/theatre/theatre.go
@@ -21,19 +21,11 @@ type Theatre struct {
 	Sources            map[string]layer.Source
 	SourceList         []layer.Source
 	Scenes             map[string]*Scene
-	Stages             map[string]*Stage
-	WindowStageList    []*Stage
-	NonWindowStageList []*Stage
+	Stages             map[string]*layer.Stage
+	WindowStageList    []*layer.Stage
+	NonWindowStageList []*layer.Stage
 
 	listener map[string][]EventListener
-}
-
-type Stage struct {
-	Layers       []*layer.Layer
-	HFlip        bool
-	VFlip        bool
-	Sink         layer.Sink
-	DefaultScene string
 }
 
 func New(cfg *config.Config, alloc encdec.FrameAllocator) (*Theatre, error) {
@@ -44,8 +36,8 @@ func New(cfg *config.Config, alloc encdec.FrameAllocator) (*Theatre, error) {
 	sourceMap := buildSourceMap(sourceList)
 	sceneMap := buildSceneMap(cfg, sourceList)
 	stageMap := buildStageMap(cfg, sourceList, alloc)
-	var windowStageList []*Stage
-	var nonWindowStageList []*Stage
+	var windowStageList []*layer.Stage
+	var nonWindowStageList []*layer.Stage
 
 	for _, stage := range stageMap {
 		switch stage.Sink.(type) {
@@ -68,10 +60,10 @@ func New(cfg *config.Config, alloc encdec.FrameAllocator) (*Theatre, error) {
 	}, nil
 }
 
-func buildStageMap(cfg *config.Config, sources []layer.Source, alloc encdec.FrameAllocator) map[string]*Stage {
-	stages := make(map[string]*Stage)
+func buildStageMap(cfg *config.Config, sources []layer.Source, alloc encdec.FrameAllocator) map[string]*layer.Stage {
+	stages := make(map[string]*layer.Stage)
 	for stageName, stageCfg := range cfg.Stages {
-		stage := &Stage{}
+		stage := &layer.Stage{}
 		stage.Layers = make([]*layer.Layer, len(sources))
 		stage.DefaultScene = stageCfg.DefaultScene
 
@@ -214,7 +206,7 @@ func (t *Theatre) SetScene(stageName string, sceneName string) error {
 	}
 }
 
-func (t *Theatre) GetTheSingleWindowStage() *Stage {
+func (t *Theatre) GetTheSingleWindowStage() *layer.Stage {
 	if len(t.WindowStageList) < 1 {
 		panic("we still don't support running without a window-type sink :(")
 	}
@@ -229,15 +221,4 @@ func (t *Theatre) ShaderData() *shaders.ShaderData {
 		NumSources: t.NumSources(),
 		Sources:    t.SourceList,
 	}
-}
-
-func (s *Stage) StageData() uint32 {
-	data := uint32(0)
-	if s.HFlip {
-		data += 1
-	}
-	if s.VFlip {
-		data += 2
-	}
-	return data
 }

--- a/lib/theatre/theatre.go
+++ b/lib/theatre/theatre.go
@@ -26,6 +26,8 @@ type Theatre struct {
 	NonWindowStageList []*layer.Stage
 
 	listener map[string][]EventListener
+
+	ShutdownRequested bool
 }
 
 func New(cfg *config.Config, alloc encdec.FrameAllocator) (*Theatre, error) {

--- a/lib/theatre/theatre.go
+++ b/lib/theatre/theatre.go
@@ -49,7 +49,7 @@ func New(cfg *config.Config, alloc encdec.FrameAllocator) (*Theatre, error) {
 		}
 	}
 
-	return &Theatre{
+	t := &Theatre{
 		Sources:            sourceMap,
 		SourceList:         sourceList,
 		Scenes:             sceneMap,
@@ -57,7 +57,14 @@ func New(cfg *config.Config, alloc encdec.FrameAllocator) (*Theatre, error) {
 		WindowStageList:    windowStageList,
 		NonWindowStageList: nonWindowStageList,
 		listener:           make(map[string][]EventListener),
-	}, nil
+	}
+
+	err = t.ResetToDefaultScenes()
+	if err != nil {
+		return nil, err
+	}
+
+	return t, nil
 }
 
 func buildStageMap(cfg *config.Config, sources []layer.Source, alloc encdec.FrameAllocator) map[string]*layer.Stage {
@@ -204,6 +211,19 @@ func (t *Theatre) SetScene(stageName string, sceneName string) error {
 	} else {
 		return fmt.Errorf("no such stage: %s", stageName)
 	}
+}
+
+func (t *Theatre) ResetToDefaultScenes() error {
+	for name, stage := range t.Stages {
+		err := t.SetScene(name, stage.DefaultScene)
+		if err != nil {
+			return fmt.Errorf(
+				"could not apply default scene (%s) to stage %s: %w",
+				stage.DefaultScene, name, err,
+			)
+		}
+	}
+	return nil
 }
 
 func (t *Theatre) GetTheSingleWindowStage() *layer.Stage {

--- a/lib/theatre/theatre.go
+++ b/lib/theatre/theatre.go
@@ -18,16 +18,19 @@ import (
 )
 
 type Theatre struct {
-	Sources            map[string]layer.Source
-	SourceList         []layer.Source
-	Scenes             map[string]*Scene
-	Stages             map[string]*layer.Stage
+	Sources    map[string]layer.Source
+	SourceList []layer.Source
+	Scenes     map[string]*Scene
+	Stages     map[string]*layer.Stage
+
 	WindowStageList    []*layer.Stage
 	NonWindowStageList []*layer.Stage
 
-	listener map[string][]EventListener
+	WindowSinkList []*windowsink.WindowSink
 
 	ShutdownRequested bool
+
+	listener map[string][]EventListener
 }
 
 func New(cfg *config.Config, alloc encdec.FrameAllocator) (*Theatre, error) {
@@ -39,12 +42,14 @@ func New(cfg *config.Config, alloc encdec.FrameAllocator) (*Theatre, error) {
 	sceneMap := buildSceneMap(cfg, sourceList)
 	stageMap := buildStageMap(cfg, sourceList, alloc)
 	var windowStageList []*layer.Stage
+	var windowSinkList []*windowsink.WindowSink
 	var nonWindowStageList []*layer.Stage
 
 	for _, stage := range stageMap {
-		switch stage.Sink.(type) {
+		switch sink := stage.Sink.(type) {
 		case *windowsink.WindowSink:
 			windowStageList = append(windowStageList, stage)
+			windowSinkList = append(windowSinkList, sink)
 		default:
 			stage.HFlip = true
 			nonWindowStageList = append(nonWindowStageList, stage)
@@ -59,6 +64,7 @@ func New(cfg *config.Config, alloc encdec.FrameAllocator) (*Theatre, error) {
 		WindowStageList:    windowStageList,
 		NonWindowStageList: nonWindowStageList,
 		listener:           make(map[string][]EventListener),
+		WindowSinkList:     windowSinkList,
 	}
 
 	err = t.ResetToDefaultScenes()
@@ -226,16 +232,6 @@ func (t *Theatre) ResetToDefaultScenes() error {
 		}
 	}
 	return nil
-}
-
-func (t *Theatre) GetTheSingleWindowStage() *layer.Stage {
-	if len(t.WindowStageList) < 1 {
-		panic("we still don't support running without a window-type sink :(")
-	}
-	if len(t.WindowStageList) > 1 {
-		panic("we still don't support multiple window-type sinks :(")
-	}
-	return t.WindowStageList[0]
 }
 
 func (t *Theatre) ShaderData() *shaders.ShaderData {

--- a/lib/utils/delta_timer.go
+++ b/lib/utils/delta_timer.go
@@ -1,0 +1,22 @@
+package utils
+
+import "time"
+
+type DeltaTimer struct {
+	time.Time
+}
+
+func (d *DeltaTimer) Next() time.Duration {
+	// acquire timestamp exactly once to ensure we're not accumulating error
+	now := time.Now()
+
+	defer d.Set(now)
+	if d.IsZero() {
+		return 0
+	}
+	return now.Sub(d.Time)
+}
+
+func (d *DeltaTimer) Set(t time.Time) {
+	d.Time = t
+}

--- a/lib/v4lsource/v4lsource.go
+++ b/lib/v4lsource/v4lsource.go
@@ -154,25 +154,35 @@ func (s *V4LSource) decodeFrames() {
 func (s *V4LSource) decodeFramesJPEG() {
 	// this does not work, dunno why
 	for rawFrame := range s.rawCamFrames {
-		frame := s.frames.GetBlankFrame()
+		frame := s.frames.GetFrameForWriting()
+		if frame == nil {
+			continue // drop the frame as instructed
+		}
+
 		err := encdec.DecodeRGBfromImage(rawFrame, frame)
 		if err != nil {
 			s.log("Could not decode frame: %s", err)
+			s.frames.FailedWriting(frame)
 			continue
 		}
-		s.frames.SendFrame(frame)
+		s.frames.FinishedWriting(frame)
 	}
 }
 
 func (s *V4LSource) decodeFrames422p() {
 	for rawFrame := range s.rawCamFrames {
-		frame := s.frames.GetBlankFrame()
+		frame := s.frames.GetFrameForWriting()
+		if frame == nil {
+			continue // drop the frame as instructed
+		}
+
 		err := encdec.DecodeYUYV422(rawFrame, frame)
 		if err != nil {
 			s.log("Could not decode frame: %s", err)
+			s.frames.FailedWriting(frame)
 			continue
 		}
-		s.frames.SendFrame(frame)
+		s.frames.FinishedWriting(frame)
 	}
 }
 


### PR DESCRIPTION
I started refactoring `FrameForwarder` in a way that would correctly handle dropped frames and would never cause race conditions, but to do that I had to refactor its API. Then one thing lead to another, and this PR:
- Refactors `FrameForwarder`'s API in the aforementioned way
- Moves all GL-related calls out of `mixer.go` and into separate functions in `rendering`
- Removes code duplication between Window and non-Window stages
- Moves Stats into a separate package
- Adds an API call that kills fazantix
- Sources are now passed instead of Layers in places where it makes sense
- Ensures that the default scenes are set after initialising the API event listener