### PR TITLE
Allow multiple ways to specify the position of a layer

### DIFF
--- a/examples/imagesource.yaml
+++ b/examples/imagesource.yaml
@@ -42,14 +42,14 @@ scenes:
       scale: 1
       opacity: 1
     test1:
-      x: 0.03
-      y: 0.25
-      scale: 0.45
+      cx: 0.25
+      cy: 0.5
+      left: 0.01
       opacity: 1
     test2:
-      x: 0.52
-      y: 0.25
-      scale: 0.45
+      cx: 0.75
+      cy: 0.5
+      right: 0.01
       opacity: 1
   full-1:
     background:
@@ -58,9 +58,9 @@ scenes:
       scale: 1
       opacity: 1
     test1:
-      x: 0.03
-      y: 0.03
-      scale: 0.93
+      cy: 0.5
+      left: -0.03
+      right: -0.03
       opacity: 1
     test2:
       opacity: 0
@@ -95,14 +95,14 @@ scenes:
       scale: 1
       opacity: 1
     test1:
-      x: 0.025
-      y: 0.049
+      left: -0.04
+      top: -0.04
       scale: 0.79
       opacity: 1
     test2:
-      x: 0.75
-      y: 0.6
-      scale: 0.2
+      right: -0.04
+      bottom: -0.1
+      scale: 0.25
       opacity: 1
 
 sinks:

--- a/lib/config/config.go
+++ b/lib/config/config.go
@@ -62,6 +62,12 @@ func (c *Config) Validate() error {
 			return fmt.Errorf("source %s is invalid: %w", k, err)
 		}
 	}
+	for k, v := range c.Scenes {
+		for ks, vs := range v {
+			err = vs.Validate()
+			if err != nil {return fmt.Errorf("scene %s layer %s is invalid: %w", k, ks, err)}
+		}
+	}
 	for k, v := range c.Stages {
 		err = v.Validate()
 		if err != nil {

--- a/lib/config/config.go
+++ b/lib/config/config.go
@@ -6,13 +6,12 @@ import (
 	"path/filepath"
 
 	"github.com/fosdem/fazantix/lib/encdec"
-	"github.com/fosdem/fazantix/lib/layer"
 	yaml "github.com/goccy/go-yaml"
 )
 
 type Config struct {
 	Sources map[string]*SourceCfg
-	Scenes  map[string]map[string]*layer.LayerState
+	Scenes  map[string]map[string]*LayerCfg
 	Stages  map[string]*StageCfg `yaml:"sinks"`
 	Api     *ApiCfg
 }
@@ -65,7 +64,9 @@ func (c *Config) Validate() error {
 	for k, v := range c.Scenes {
 		for ks, vs := range v {
 			err = vs.Validate()
-			if err != nil {return fmt.Errorf("scene %s layer %s is invalid: %w", k, ks, err)}
+			if err != nil {
+				return fmt.Errorf("scene %s layer %s is invalid: %w", k, ks, err)
+			}
 		}
 	}
 	for k, v := range c.Stages {
@@ -195,6 +196,7 @@ func (s *StageCfg) Validate() error {
 func (s *SourceCfg) Validate() error {
 	return s.Cfg.Validate()
 }
+
 func (s *ImgSourceCfg) Validate() error {
 	if s.Path == "" {
 		return fmt.Errorf("image path must be specified")

--- a/lib/config/layer.go
+++ b/lib/config/layer.go
@@ -21,68 +21,68 @@ type LayerCfgExtendedPositioning struct {
 	Cy     float32
 }
 
-func (s *LayerCfg) Validate() error {
-	if s.X != 0 && (s.Left != 0 || s.Right != 0) {
+func (l *LayerCfg) Validate() error {
+	if l.X != 0 && (l.Left != 0 || l.Right != 0) {
 		return fmt.Errorf("cannot set both X and Left or Right for the position")
 	}
-	if s.Y != 0 && (s.Top != 0 || s.Bottom != 0) {
+	if l.Y != 0 && (l.Top != 0 || l.Bottom != 0) {
 		return fmt.Errorf("cannot set both Y and Top or Bottom for the position")
 	}
-	if s.Top != 0 && s.Bottom != 0 && s.Left != 0 && s.Right != 0 {
+	if l.Top != 0 && l.Bottom != 0 && l.Left != 0 && l.Right != 0 {
 		return fmt.Errorf("cannot define all four edges for position")
 	}
 
-	s.Left = normalize(s.Left, 9.0/16)
-	s.Right = normalize(s.Right, 9.0/16)
-	s.Top = normalize(s.Top, 1)
-	s.Bottom = normalize(s.Bottom, 1)
+	l.Left = normalize(l.Left, 9.0/16)
+	l.Right = normalize(l.Right, 9.0/16)
+	l.Top = normalize(l.Top, 1)
+	l.Bottom = normalize(l.Bottom, 1)
 
-	if s.Scale == 0 {
-		if s.Left != 0 && s.Right != 0 {
-			s.Scale = 1.0 - s.Left - s.Right
-		} else if s.Top != 0 && s.Bottom != 0 {
-			s.Scale = 1.0 - s.Top - s.Bottom
+	if l.Scale == 0 {
+		if l.Left != 0 && l.Right != 0 {
+			l.Scale = 1.0 - l.Left - l.Right
+		} else if l.Top != 0 && l.Bottom != 0 {
+			l.Scale = 1.0 - l.Top - l.Bottom
 		}
 	}
 
-	if s.X == 0 && s.Y == 0 {
-		if s.Left != 0 {
-			s.X = s.Left
+	if l.X == 0 && l.Y == 0 {
+		if l.Left != 0 {
+			l.X = l.Left
 		} else {
-			s.X = (1.0 - s.Right) - s.Scale
+			l.X = (1.0 - l.Right) - l.Scale
 		}
-		if s.Top != 0 {
-			s.Y = s.Top
+		if l.Top != 0 {
+			l.Y = l.Top
 		} else {
-			s.Y = (1.0 - s.Bottom) - s.Scale
+			l.Y = (1.0 - l.Bottom) - l.Scale
 		}
 	}
 
-	if s.Cx != 0 {
-		if s.Scale == 0 {
+	if l.Cx != 0 {
+		if l.Scale == 0 {
 			// Figure out scale from an edge constraint
-			if s.Left != 0 {
-				s.Scale = (s.Cx - s.Left) * 2
-			} else if s.Right != 0 {
-				s.Scale = ((1.0 - s.Cx) - s.Right) * 2
+			if l.Left != 0 {
+				l.Scale = (l.Cx - l.Left) * 2
+			} else if l.Right != 0 {
+				l.Scale = ((1.0 - l.Cx) - l.Right) * 2
 			} else {
 				return fmt.Errorf("horisontal scale undercontrained")
 			}
 		}
-		s.X = s.Cx - (s.Scale / 2)
+		l.X = l.Cx - (l.Scale / 2)
 	}
-	if s.Cy != 0 {
-		if s.Scale == 0 {
+	if l.Cy != 0 {
+		if l.Scale == 0 {
 			// Figure out scale from an edge constraint
-			if s.Top != 0 {
-				s.Scale = (s.Cy - s.Top) * 2
-			} else if s.Bottom != 0 {
-				s.Scale = ((1.0 - s.Cy) - s.Bottom) * 2
+			if l.Top != 0 {
+				l.Scale = (l.Cy - l.Top) * 2
+			} else if l.Bottom != 0 {
+				l.Scale = ((1.0 - l.Cy) - l.Bottom) * 2
 			} else {
 				return fmt.Errorf("vertical scale undercontrained")
 			}
 		}
-		s.Y = s.Cy - (s.Scale / 2)
+		l.Y = l.Cy - (l.Scale / 2)
 	}
 
 	return nil

--- a/lib/config/layer.go
+++ b/lib/config/layer.go
@@ -1,0 +1,120 @@
+package config
+
+import (
+	"fmt"
+
+	"github.com/fosdem/fazantix/lib/layer"
+	yaml "github.com/goccy/go-yaml"
+)
+
+type LayerCfg struct {
+	layer.LayerState
+	LayerCfgExtendedPositioning
+}
+
+type LayerCfgExtendedPositioning struct {
+	Top    float32
+	Left   float32
+	Bottom float32
+	Right  float32
+	Cx     float32
+	Cy     float32
+}
+
+func (s *LayerCfg) Validate() error {
+	if s.X != 0 && (s.Left != 0 || s.Right != 0) {
+		return fmt.Errorf("cannot set both X and Left or Right for the position")
+	}
+	if s.Y != 0 && (s.Top != 0 || s.Bottom != 0) {
+		return fmt.Errorf("cannot set both Y and Top or Bottom for the position")
+	}
+	if s.Top != 0 && s.Bottom != 0 && s.Left != 0 && s.Right != 0 {
+		return fmt.Errorf("cannot define all four edges for position")
+	}
+
+	s.Left = normalize(s.Left, 9.0/16)
+	s.Right = normalize(s.Right, 9.0/16)
+	s.Top = normalize(s.Top, 1)
+	s.Bottom = normalize(s.Bottom, 1)
+
+	if s.Scale == 0 {
+		if s.Left != 0 && s.Right != 0 {
+			s.Scale = 1.0 - s.Left - s.Right
+		} else if s.Top != 0 && s.Bottom != 0 {
+			s.Scale = 1.0 - s.Top - s.Bottom
+		}
+	}
+
+	if s.X == 0 && s.Y == 0 {
+		if s.Left != 0 {
+			s.X = s.Left
+		} else {
+			s.X = (1.0 - s.Right) - s.Scale
+		}
+		if s.Top != 0 {
+			s.Y = s.Top
+		} else {
+			s.Y = (1.0 - s.Bottom) - s.Scale
+		}
+	}
+
+	if s.Cx != 0 {
+		if s.Scale == 0 {
+			// Figure out scale from an edge constraint
+			if s.Left != 0 {
+				s.Scale = (s.Cx - s.Left) * 2
+			} else if s.Right != 0 {
+				s.Scale = ((1.0 - s.Cx) - s.Right) * 2
+			} else {
+				return fmt.Errorf("horisontal scale undercontrained")
+			}
+		}
+		s.X = s.Cx - (s.Scale / 2)
+	}
+	if s.Cy != 0 {
+		if s.Scale == 0 {
+			// Figure out scale from an edge constraint
+			if s.Top != 0 {
+				s.Scale = (s.Cy - s.Top) * 2
+			} else if s.Bottom != 0 {
+				s.Scale = ((1.0 - s.Cy) - s.Bottom) * 2
+			} else {
+				return fmt.Errorf("vertical scale undercontrained")
+			}
+		}
+		s.Y = s.Cy - (s.Scale / 2)
+	}
+
+	return nil
+}
+
+func (l *LayerCfg) CopyState() *layer.LayerState {
+	if l == nil {
+		return nil
+	}
+	ls := l.LayerState
+	return &ls
+}
+
+func (l *LayerCfg) UnmarshalYAML(b []byte) error {
+	err := yaml.Unmarshal(b, &l.LayerState)
+	if err != nil {
+		return err
+	}
+
+	err = yaml.Unmarshal(b, &l.LayerCfgExtendedPositioning)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func normalize(value float32, aspect float32) float32 {
+	if value >= 0 {
+		return value
+	}
+	value *= -1
+	value *= aspect
+	return value
+}

--- a/lib/layer/layer.go
+++ b/lib/layer/layer.go
@@ -1,6 +1,7 @@
 package layer
 
 import (
+	"fmt"
 	"math"
 )
 
@@ -36,7 +37,89 @@ type LayerState struct {
 	X       float32
 	Y       float32
 	Scale   float32
+	Top     float32
+	Left    float32
+	Bottom  float32
+	Right   float32
+	Cx      float32
+	Cy      float32
 	Opacity float32
+}
+
+func normalize(value float32, aspect float32) float32 {
+	if value >= 0 {
+		return value
+	}
+	value *= -1
+	value *= aspect
+	return value
+}
+
+func (s *LayerState) Validate() error {
+	if s.X != 0 && (s.Left != 0 || s.Right != 0) {
+		return fmt.Errorf("cannot set both X and Left or Right for the position")
+	}
+	if s.Y != 0 && (s.Top != 0 || s.Bottom != 0) {
+		return fmt.Errorf("cannot set both Y and Top or Bottom for the position")
+	}
+	if s.Top != 0 && s.Bottom != 0 && s.Left != 0 && s.Right != 0 {
+		return fmt.Errorf("cannot define all four edges for position")
+	}
+
+	s.Left = normalize(s.Left, 9.0/16)
+	s.Right = normalize(s.Right, 9.0/16)
+	s.Top = normalize(s.Top, 1)
+	s.Bottom = normalize(s.Bottom, 1)
+
+	if s.Scale == 0 {
+		if s.Left != 0 && s.Right != 0 {
+			s.Scale = 1.0 - s.Left - s.Right
+		} else if s.Top != 0 && s.Bottom != 0 {
+			s.Scale = 1.0 - s.Top - s.Bottom
+		}
+	}
+
+	if s.X == 0 && s.Y == 0 {
+		if s.Left != 0 {
+			s.X = s.Left
+		} else {
+			s.X = (1.0 - s.Right) - s.Scale
+		}
+		if s.Top != 0 {
+			s.Y = s.Top
+		} else {
+			s.Y = (1.0 - s.Bottom) - s.Scale
+		}
+	}
+
+	if s.Cx != 0 {
+		if s.Scale == 0 {
+			// Figure out scale from an edge constraint
+			if s.Left != 0 {
+				s.Scale = (s.Cx - s.Left) * 2
+			} else if s.Right != 0 {
+				s.Scale = ((1.0 - s.Cx) - s.Right) * 2
+			} else {
+				return fmt.Errorf("horisontal scale undercontrained")
+			}
+		}
+		s.X = s.Cx - (s.Scale / 2)
+	}
+	if s.Cy != 0 {
+		if s.Scale == 0 {
+			// Figure out scale from an edge constraint
+			if s.Top != 0 {
+				s.Scale = (s.Cy - s.Top) * 2
+			} else if s.Bottom != 0 {
+				s.Scale = ((1.0 - s.Cy) - s.Bottom) * 2
+			} else {
+				return fmt.Errorf("vertical scale undercontrained")
+			}
+		}
+		s.Y = s.Cy - (s.Scale / 2)
+	}
+
+	return nil
 }
 
 func New(src Source, width int, height int) *Layer {

--- a/lib/layer/layer.go
+++ b/lib/layer/layer.go
@@ -1,7 +1,6 @@
 package layer
 
 import (
-	"fmt"
 	"math"
 )
 
@@ -37,89 +36,7 @@ type LayerState struct {
 	X       float32
 	Y       float32
 	Scale   float32
-	Top     float32
-	Left    float32
-	Bottom  float32
-	Right   float32
-	Cx      float32
-	Cy      float32
 	Opacity float32
-}
-
-func normalize(value float32, aspect float32) float32 {
-	if value >= 0 {
-		return value
-	}
-	value *= -1
-	value *= aspect
-	return value
-}
-
-func (s *LayerState) Validate() error {
-	if s.X != 0 && (s.Left != 0 || s.Right != 0) {
-		return fmt.Errorf("cannot set both X and Left or Right for the position")
-	}
-	if s.Y != 0 && (s.Top != 0 || s.Bottom != 0) {
-		return fmt.Errorf("cannot set both Y and Top or Bottom for the position")
-	}
-	if s.Top != 0 && s.Bottom != 0 && s.Left != 0 && s.Right != 0 {
-		return fmt.Errorf("cannot define all four edges for position")
-	}
-
-	s.Left = normalize(s.Left, 9.0/16)
-	s.Right = normalize(s.Right, 9.0/16)
-	s.Top = normalize(s.Top, 1)
-	s.Bottom = normalize(s.Bottom, 1)
-
-	if s.Scale == 0 {
-		if s.Left != 0 && s.Right != 0 {
-			s.Scale = 1.0 - s.Left - s.Right
-		} else if s.Top != 0 && s.Bottom != 0 {
-			s.Scale = 1.0 - s.Top - s.Bottom
-		}
-	}
-
-	if s.X == 0 && s.Y == 0 {
-		if s.Left != 0 {
-			s.X = s.Left
-		} else {
-			s.X = (1.0 - s.Right) - s.Scale
-		}
-		if s.Top != 0 {
-			s.Y = s.Top
-		} else {
-			s.Y = (1.0 - s.Bottom) - s.Scale
-		}
-	}
-
-	if s.Cx != 0 {
-		if s.Scale == 0 {
-			// Figure out scale from an edge constraint
-			if s.Left != 0 {
-				s.Scale = (s.Cx - s.Left) * 2
-			} else if s.Right != 0 {
-				s.Scale = ((1.0 - s.Cx) - s.Right) * 2
-			} else {
-				return fmt.Errorf("horisontal scale undercontrained")
-			}
-		}
-		s.X = s.Cx - (s.Scale / 2)
-	}
-	if s.Cy != 0 {
-		if s.Scale == 0 {
-			// Figure out scale from an edge constraint
-			if s.Top != 0 {
-				s.Scale = (s.Cy - s.Top) * 2
-			} else if s.Bottom != 0 {
-				s.Scale = ((1.0 - s.Cy) - s.Bottom) * 2
-			} else {
-				return fmt.Errorf("vertical scale undercontrained")
-			}
-		}
-		s.Y = s.Cy - (s.Scale / 2)
-	}
-
-	return nil
 }
 
 func New(src Source, width int, height int) *Layer {

--- a/lib/theatre/theatre.go
+++ b/lib/theatre/theatre.go
@@ -102,10 +102,11 @@ func buildStageMap(cfg *config.Config, sources []layer.Source, alloc encdec.Fram
 
 func buildSceneMap(cfg *config.Config, sources []layer.Source) map[string]*Scene {
 	scenes := make(map[string]*Scene)
-	for sceneName, layerStateMap := range cfg.Scenes {
+	for sceneName, layerCfgMap := range cfg.Scenes {
 		layerStates := make([]*layer.LayerState, len(sources))
 		for i, src := range sources {
-			layerStates[i] = layerStateMap[src.Frames().Name]
+			layerStates[i] = layerCfgMap[src.Frames().Name].CopyState()
+			log.Printf("layer state %d: %+v", i, layerStates[i])
 		}
 		scenes[sceneName] = &Scene{
 			Name:        sceneName,
@@ -117,8 +118,8 @@ func buildSceneMap(cfg *config.Config, sources []layer.Source) map[string]*Scene
 
 func buildSourceList(cfg *config.Config, alloc encdec.FrameAllocator) ([]layer.Source, error) {
 	enabledSources := make(map[string]struct{})
-	for _, layerStateMap := range cfg.Scenes {
-		for name := range layerStateMap {
+	for _, layerCfgMap := range cfg.Scenes {
+		for name := range layerCfgMap {
 			if _, ok := cfg.Sources[name]; ok {
 				enabledSources[name] = struct{}{}
 			} else {


### PR DESCRIPTION
For many layouts its way more convenient to specify distance to the screen edge or position from the center coordinate of the source so this allows specifying several position contraints:

* x, y: put top-left corner of layer at position
* left: put left edge of the source this distance away from the left screen edge. Negative numbers normalize for the aspect ratio
* right: put right edge of the source this distance away from the right screen edge. Negative numbers normalize for the aspect ratio
* top: put top edge of the source this distance away from the top screen edge. Negative numbers are abs()'ed
* bottom: put top edge of the source this distance away from the bottom screen edge. Negative numbers are abs()'ed
* cx, cy: put the center of the layer at position
* scale: The size of the layer in ratio to the screen size

Unspecified variables will be calculated from the specified constraints. For example a position and an edge location is enough to calculate a scale and three edge locations are enough to calculate the position and scale.