### PR TITLE
Implement warps for layer state

### DIFF
--- a/examples/imagesource.yaml
+++ b/examples/imagesource.yaml
@@ -21,15 +21,6 @@ sources:
     path: images/testsrc3.png
     makescene: true
     z: 3
-  video0:
-    type: v4l
-    path: /dev/video0
-    fmt: yuyv
-    frames:
-      width: 1920
-      height: 1080
-      num_allocated_frames: 5
-    z: 1
   video_listen:
     type: ffmpeg_stdout
     cmd: 'ffmpeg -stream_loop -1 -re -i "tcp://0.0.0.0:7788?listen=1&recv_buffer_size=1048576" -vf scale=1920:1080 -pix_fmt yuv422p -f rawvideo -r 60 -'
@@ -84,6 +75,11 @@ scenes:
         y: 0.03
         scale: 0.93
         opacity: 1
+        warp:
+          x: 0.03
+          y: 0.03
+          scale: 0.93
+          opacity: 0
   full-2:
     sources:
       background:
@@ -96,6 +92,12 @@ scenes:
         y: 0.03
         scale: 0.93
         opacity: 1
+        warp:
+          x: 0.03
+          y: 0.03
+          scale: 0.93
+          opacity: 0
+
       test1:
         opacity: 0
   default:
@@ -106,16 +108,27 @@ scenes:
         y: 0
         scale: 1
         opacity: 1
-      video0:
+      test1:
         left: -0.04
         top: -0.04
         scale: 0.79
         opacity: 1
+        warp:
+          opacity: 0
+          cx: 0.5
+          cy: 0.5
+          scale: 0.1
       test2:
         right: -0.04
         bottom: -0.1
         scale: 0.25
         opacity: 1
+        warp:
+          opacity: 1
+          scale: 0.001
+          right: -0.04
+          bottom: -0.1
+
 
 sinks:
   projector:

--- a/examples/imagesource.yaml
+++ b/examples/imagesource.yaml
@@ -61,8 +61,11 @@ scenes:
         left: -0.03
         right: -0.03
         opacity: 1
-      test2:
-        opacity: 0
+        warp:
+          x: 0.03
+          y: 0.03
+          scale: 0.9
+          opacity: 0
   full-3:
     sources:
       background:
@@ -97,9 +100,6 @@ scenes:
           y: 0.03
           scale: 0.93
           opacity: 0
-
-      test1:
-        opacity: 0
   default:
     tag: "dflt"
     sources:

--- a/lib/config/layer.go
+++ b/lib/config/layer.go
@@ -7,120 +7,57 @@ import (
 	yaml "github.com/goccy/go-yaml"
 )
 
-type LayerWarpCfg struct {
-	layer.LayerState
+type LayerStateCfg struct {
+	layer.LayerTransform
 	LayerCfgExtendedPositioning
-}
-
-type LayerWarpIntermediateState struct {
-	Warp layer.LayerState
-}
-type LayerWarpIntermediateExt struct {
-	Warp LayerCfgExtendedPositioning
 }
 
 type LayerCfg struct {
-	layer.LayerState
-	LayerCfgExtendedPositioning
-	Warp LayerWarpCfg
+	LayerStateCfg
+	LayerCfgStub
 }
 
-type LayerCfgExtendedPositioning struct {
-	Top    float32
-	Left   float32
-	Bottom float32
-	Right  float32
-	Cx     float32
-	Cy     float32
+type LayerCfgStub struct {
+	Warp *LayerStateCfg `yaml:"warp"`
 }
 
 func (l *LayerCfg) Validate() error {
-	err := applyExtendedPositions(&l.LayerState, &l.LayerCfgExtendedPositioning)
+	err := l.LayerStateCfg.Validate()
 	if err != nil {
 		return err
 	}
-	err = applyExtendedPositions(&l.Warp.LayerState, &l.Warp.LayerCfgExtendedPositioning)
+
+	if l.Warp != nil {
+		err = l.Warp.Validate()
+		if err != nil {
+			return fmt.Errorf("warp config is invalid: %w", err)
+		}
+	}
 	return err
 }
 
-func applyExtendedPositions(l *layer.LayerState, ext *LayerCfgExtendedPositioning) error {
-	if l.X != 0 && (ext.Left != 0 || ext.Right != 0) {
-		return fmt.Errorf("cannot set both X and Left or Right for the position")
-	}
-	if l.Y != 0 && (ext.Top != 0 || ext.Bottom != 0) {
-		return fmt.Errorf("cannot set both Y and Top or Bottom for the position")
-	}
-	if ext.Top != 0 && ext.Bottom != 0 && ext.Left != 0 && ext.Right != 0 {
-		return fmt.Errorf("cannot define all four edges for position")
-	}
-
-	ext.Left = normalize(ext.Left, 9.0/16)
-	ext.Right = normalize(ext.Right, 9.0/16)
-	ext.Top = normalize(ext.Top, 1)
-	ext.Bottom = normalize(ext.Bottom, 1)
-
-	if l.Scale == 0 {
-		if ext.Left != 0 && ext.Right != 0 {
-			l.Scale = 1.0 - ext.Left - ext.Right
-		} else if ext.Top != 0 && ext.Bottom != 0 {
-			l.Scale = 1.0 - ext.Top - ext.Bottom
-		}
-	}
-
-	if l.X == 0 && l.Y == 0 {
-		if ext.Left != 0 {
-			l.X = ext.Left
-		} else {
-			l.X = (1.0 - ext.Right) - l.Scale
-		}
-		if ext.Top != 0 {
-			l.Y = ext.Top
-		} else {
-			l.Y = (1.0 - ext.Bottom) - l.Scale
-		}
-	}
-
-	if ext.Cx != 0 {
-		if l.Scale == 0 {
-			// Figure out scale from an edge constraint
-			if ext.Left != 0 {
-				l.Scale = (ext.Cx - ext.Left) * 2
-			} else if ext.Right != 0 {
-				l.Scale = ((1.0 - ext.Cx) - ext.Right) * 2
-			} else {
-				return fmt.Errorf("horisontal scale undercontrained")
-			}
-		}
-		l.X = ext.Cx - (l.Scale / 2)
-	}
-	if ext.Cy != 0 {
-		if l.Scale == 0 {
-			// Figure out scale from an edge constraint
-			if ext.Top != 0 {
-				l.Scale = (ext.Cy - ext.Top) * 2
-			} else if ext.Bottom != 0 {
-				l.Scale = ((1.0 - ext.Cy) - ext.Bottom) * 2
-			} else {
-				return fmt.Errorf("vertical scale undercontrained")
-			}
-		}
-		l.Y = ext.Cy - (l.Scale / 2)
-	}
-
-	return nil
+func (l *LayerStateCfg) Validate() error {
+	return applyExtendedPositions(&l.LayerTransform, &l.LayerCfgExtendedPositioning)
 }
 
-func (l *LayerCfg) CopyState() (*layer.LayerState, *layer.LayerState) {
+func (l *LayerCfg) CopyState() *layer.LayerState {
 	if l == nil {
-		return nil, nil
+		return nil
 	}
-	ls := l.LayerState
-	ws := l.Warp.LayerState
-	return &ls, &ws
+	var warp *layer.LayerTransform
+	if l.Warp != nil {
+		warp = &layer.LayerTransform{}
+		*warp = l.Warp.LayerTransform
+	}
+
+	return &layer.LayerState{
+		LayerTransform: l.LayerTransform,
+		Warp:           warp,
+	}
 }
 
-func (l *LayerCfg) UnmarshalYAML(b []byte) error {
-	err := yaml.Unmarshal(b, &l.LayerState)
+func (l *LayerStateCfg) UnmarshalYAML(b []byte) error {
+	err := yaml.Unmarshal(b, &l.LayerTransform)
 	if err != nil {
 		return err
 	}
@@ -129,20 +66,20 @@ func (l *LayerCfg) UnmarshalYAML(b []byte) error {
 	if err != nil {
 		return err
 	}
+	return nil
+}
 
-	var tempState = LayerWarpIntermediateState{}
-	var tempExt = LayerWarpIntermediateExt{}
-
-	err = yaml.Unmarshal(b, &tempState)
+func (l *LayerCfg) UnmarshalYAML(b []byte) error {
+	err := yaml.Unmarshal(b, &l.LayerCfgStub)
 	if err != nil {
 		return err
 	}
-	err = yaml.Unmarshal(b, &tempExt)
+
+	err = yaml.Unmarshal(b, &l.LayerStateCfg)
 	if err != nil {
 		return err
 	}
-	l.Warp.LayerState = tempState.Warp
-	l.Warp.LayerCfgExtendedPositioning = tempExt.Warp
+
 	return nil
 }
 

--- a/lib/config/layer.go
+++ b/lib/config/layer.go
@@ -7,9 +7,22 @@ import (
 	yaml "github.com/goccy/go-yaml"
 )
 
+type LayerWarpCfg struct {
+	layer.LayerState
+	LayerCfgExtendedPositioning
+}
+
+type LayerWarpIntermediateState struct {
+	Warp layer.LayerState
+}
+type LayerWarpIntermediateExt struct {
+	Warp LayerCfgExtendedPositioning
+}
+
 type LayerCfg struct {
 	layer.LayerState
 	LayerCfgExtendedPositioning
+	Warp LayerWarpCfg
 }
 
 type LayerCfgExtendedPositioning struct {
@@ -22,78 +35,88 @@ type LayerCfgExtendedPositioning struct {
 }
 
 func (l *LayerCfg) Validate() error {
-	if l.X != 0 && (l.Left != 0 || l.Right != 0) {
+	err := applyExtendedPositions(&l.LayerState, &l.LayerCfgExtendedPositioning)
+	if err != nil {
+		return err
+	}
+	err = applyExtendedPositions(&l.Warp.LayerState, &l.Warp.LayerCfgExtendedPositioning)
+	return err
+}
+
+func applyExtendedPositions(l *layer.LayerState, ext *LayerCfgExtendedPositioning) error {
+	if l.X != 0 && (ext.Left != 0 || ext.Right != 0) {
 		return fmt.Errorf("cannot set both X and Left or Right for the position")
 	}
-	if l.Y != 0 && (l.Top != 0 || l.Bottom != 0) {
+	if l.Y != 0 && (ext.Top != 0 || ext.Bottom != 0) {
 		return fmt.Errorf("cannot set both Y and Top or Bottom for the position")
 	}
-	if l.Top != 0 && l.Bottom != 0 && l.Left != 0 && l.Right != 0 {
+	if ext.Top != 0 && ext.Bottom != 0 && ext.Left != 0 && ext.Right != 0 {
 		return fmt.Errorf("cannot define all four edges for position")
 	}
 
-	l.Left = normalize(l.Left, 9.0/16)
-	l.Right = normalize(l.Right, 9.0/16)
-	l.Top = normalize(l.Top, 1)
-	l.Bottom = normalize(l.Bottom, 1)
+	ext.Left = normalize(ext.Left, 9.0/16)
+	ext.Right = normalize(ext.Right, 9.0/16)
+	ext.Top = normalize(ext.Top, 1)
+	ext.Bottom = normalize(ext.Bottom, 1)
 
 	if l.Scale == 0 {
-		if l.Left != 0 && l.Right != 0 {
-			l.Scale = 1.0 - l.Left - l.Right
-		} else if l.Top != 0 && l.Bottom != 0 {
-			l.Scale = 1.0 - l.Top - l.Bottom
+		if ext.Left != 0 && ext.Right != 0 {
+			l.Scale = 1.0 - ext.Left - ext.Right
+		} else if ext.Top != 0 && ext.Bottom != 0 {
+			l.Scale = 1.0 - ext.Top - ext.Bottom
 		}
 	}
 
 	if l.X == 0 && l.Y == 0 {
-		if l.Left != 0 {
-			l.X = l.Left
+		if ext.Left != 0 {
+			l.X = ext.Left
 		} else {
-			l.X = (1.0 - l.Right) - l.Scale
+			l.X = (1.0 - ext.Right) - l.Scale
 		}
-		if l.Top != 0 {
-			l.Y = l.Top
+		if ext.Top != 0 {
+			l.Y = ext.Top
 		} else {
-			l.Y = (1.0 - l.Bottom) - l.Scale
+			l.Y = (1.0 - ext.Bottom) - l.Scale
 		}
 	}
 
-	if l.Cx != 0 {
+	if ext.Cx != 0 {
 		if l.Scale == 0 {
 			// Figure out scale from an edge constraint
-			if l.Left != 0 {
-				l.Scale = (l.Cx - l.Left) * 2
-			} else if l.Right != 0 {
-				l.Scale = ((1.0 - l.Cx) - l.Right) * 2
+			if ext.Left != 0 {
+				l.Scale = (ext.Cx - ext.Left) * 2
+			} else if ext.Right != 0 {
+				l.Scale = ((1.0 - ext.Cx) - ext.Right) * 2
 			} else {
 				return fmt.Errorf("horisontal scale undercontrained")
 			}
 		}
-		l.X = l.Cx - (l.Scale / 2)
+		l.X = ext.Cx - (l.Scale / 2)
 	}
-	if l.Cy != 0 {
+	if ext.Cy != 0 {
 		if l.Scale == 0 {
 			// Figure out scale from an edge constraint
-			if l.Top != 0 {
-				l.Scale = (l.Cy - l.Top) * 2
-			} else if l.Bottom != 0 {
-				l.Scale = ((1.0 - l.Cy) - l.Bottom) * 2
+			if ext.Top != 0 {
+				l.Scale = (ext.Cy - ext.Top) * 2
+			} else if ext.Bottom != 0 {
+				l.Scale = ((1.0 - ext.Cy) - ext.Bottom) * 2
 			} else {
 				return fmt.Errorf("vertical scale undercontrained")
 			}
 		}
-		l.Y = l.Cy - (l.Scale / 2)
+		l.Y = ext.Cy - (l.Scale / 2)
 	}
 
 	return nil
 }
 
-func (l *LayerCfg) CopyState() *layer.LayerState {
+func (l *LayerCfg) CopyState() (*layer.LayerState, *layer.LayerState) {
 	if l == nil {
-		return nil
+		return nil, nil
 	}
 	ls := l.LayerState
-	return &ls
+	ws := l.Warp.LayerState
+	return &ls, &ws
 }
 
 func (l *LayerCfg) UnmarshalYAML(b []byte) error {
@@ -107,6 +130,19 @@ func (l *LayerCfg) UnmarshalYAML(b []byte) error {
 		return err
 	}
 
+	var tempState = LayerWarpIntermediateState{}
+	var tempExt = LayerWarpIntermediateExt{}
+
+	err = yaml.Unmarshal(b, &tempState)
+	if err != nil {
+		return err
+	}
+	err = yaml.Unmarshal(b, &tempExt)
+	if err != nil {
+		return err
+	}
+	l.Warp.LayerState = tempState.Warp
+	l.Warp.LayerCfgExtendedPositioning = tempExt.Warp
 	return nil
 }
 

--- a/lib/config/layer_extended_positioning.go
+++ b/lib/config/layer_extended_positioning.go
@@ -1,0 +1,83 @@
+package config
+
+import (
+	"fmt"
+
+	"github.com/fosdem/fazantix/lib/layer"
+)
+
+type LayerCfgExtendedPositioning struct {
+	Top    float32
+	Left   float32
+	Bottom float32
+	Right  float32
+	Cx     float32
+	Cy     float32
+}
+
+func applyExtendedPositions(l *layer.LayerTransform, ext *LayerCfgExtendedPositioning) error {
+	if l.X != 0 && (ext.Left != 0 || ext.Right != 0) {
+		return fmt.Errorf("cannot set both X and Left or Right for the position")
+	}
+	if l.Y != 0 && (ext.Top != 0 || ext.Bottom != 0) {
+		return fmt.Errorf("cannot set both Y and Top or Bottom for the position")
+	}
+	if ext.Top != 0 && ext.Bottom != 0 && ext.Left != 0 && ext.Right != 0 {
+		return fmt.Errorf("cannot define all four edges for position")
+	}
+
+	ext.Left = normalize(ext.Left, 9.0/16)
+	ext.Right = normalize(ext.Right, 9.0/16)
+	ext.Top = normalize(ext.Top, 1)
+	ext.Bottom = normalize(ext.Bottom, 1)
+
+	if l.Scale == 0 {
+		if ext.Left != 0 && ext.Right != 0 {
+			l.Scale = 1.0 - ext.Left - ext.Right
+		} else if ext.Top != 0 && ext.Bottom != 0 {
+			l.Scale = 1.0 - ext.Top - ext.Bottom
+		}
+	}
+
+	if l.X == 0 && l.Y == 0 {
+		if ext.Left != 0 {
+			l.X = ext.Left
+		} else {
+			l.X = (1.0 - ext.Right) - l.Scale
+		}
+		if ext.Top != 0 {
+			l.Y = ext.Top
+		} else {
+			l.Y = (1.0 - ext.Bottom) - l.Scale
+		}
+	}
+
+	if ext.Cx != 0 {
+		if l.Scale == 0 {
+			// Figure out scale from an edge constraint
+			if ext.Left != 0 {
+				l.Scale = (ext.Cx - ext.Left) * 2
+			} else if ext.Right != 0 {
+				l.Scale = ((1.0 - ext.Cx) - ext.Right) * 2
+			} else {
+				return fmt.Errorf("horisontal scale underconstrained")
+			}
+		}
+		l.X = ext.Cx - (l.Scale / 2)
+	}
+	if ext.Cy != 0 {
+		if l.Scale == 0 {
+			// Figure out scale from an edge constraint
+			if ext.Top != 0 {
+				l.Scale = (ext.Cy - ext.Top) * 2
+			} else if ext.Bottom != 0 {
+				l.Scale = ((1.0 - ext.Cy) - ext.Bottom) * 2
+			} else {
+				return fmt.Errorf("vertical scale underconstrained")
+			}
+		}
+		l.Y = ext.Cy - (l.Scale / 2)
+	}
+
+	return nil
+}

--- a/lib/layer/layer.go
+++ b/lib/layer/layer.go
@@ -1,6 +1,7 @@
 package layer
 
 import (
+	"log"
 	"math"
 )
 
@@ -59,7 +60,7 @@ func (s *Layer) Name() string {
 	return s.Source.Frames().Name
 }
 
-func (s *Layer) ApplyState(state *LayerState) {
+func (s *Layer) ApplyState(state *LayerState, warp *LayerState) {
 	if state == nil {
 		state = &LayerState{}
 		if s.targetState != nil {
@@ -68,12 +69,26 @@ func (s *Layer) ApplyState(state *LayerState) {
 		state.Opacity = 0
 	}
 
+	if s.Opacity < 0.001 && warp != nil {
+		log.Println("Warping state")
+		s.Position.X = warp.X
+		s.Position.Y = warp.Y
+		s.Size.X = warp.Scale
+		s.Size.Y = warp.Scale / s.Squeeze
+		s.Opacity = warp.Opacity
+	}
+
 	if s.targetState == nil {
-		s.Position.X = state.X
-		s.Position.Y = state.Y
-		s.Size.X = state.Scale
-		s.Size.Y = state.Scale / s.Squeeze
-		s.Opacity = state.Opacity
+		base := state
+		if warp != nil {
+			log.Println("Warping")
+			base = warp
+		}
+		s.Position.X = base.X
+		s.Position.Y = base.Y
+		s.Size.X = base.Scale
+		s.Size.Y = base.Scale / s.Squeeze
+		s.Opacity = base.Opacity
 	}
 	s.targetState = state
 }

--- a/lib/theatre/theatre.go
+++ b/lib/theatre/theatre.go
@@ -123,9 +123,10 @@ func buildSceneMap(cfg *config.Config, sources []layer.Source) map[string]*Scene
 	scenes := make(map[string]*Scene)
 	for sceneName, scene := range cfg.Scenes {
 		layerStates := make([]*layer.LayerState, len(sources))
+		layerWarps := make([]*layer.LayerState, len(sources))
 		for i, src := range sources {
-			layerStates[i] = scene.Sources[src.Frames().Name].CopyState()
-			log.Printf("layer state %d: %+v", i, layerStates[i])
+			layerStates[i], layerWarps[i] = scene.Sources[src.Frames().Name].CopyState()
+			log.Printf("layer state %d: %+v %+v", i, layerStates[i], layerWarps[i])
 		}
 		if scene.Label == "" {
 			scene.Label = sceneName
@@ -138,6 +139,7 @@ func buildSceneMap(cfg *config.Config, sources []layer.Source) map[string]*Scene
 			Label:       scene.Label,
 			Tag:         scene.Tag,
 			LayerStates: layerStates,
+			LayerWarps:  layerWarps,
 		}
 	}
 	return scenes
@@ -200,6 +202,7 @@ type Scene struct {
 	Tag         string
 	Label       string
 	LayerStates []*layer.LayerState
+	LayerWarps  []*layer.LayerState
 }
 
 func (t *Theatre) NumLayers() int {
@@ -245,7 +248,7 @@ func (t *Theatre) SetScene(stageName string, sceneName string) error {
 				Scene: sceneName,
 			})
 			for i, l := range stage.Layers {
-				l.ApplyState(scene.LayerStates[i])
+				l.ApplyState(scene.LayerStates[i], scene.LayerWarps[i])
 			}
 			return nil
 		} else {


### PR DESCRIPTION
Add a new `warp: key` for the layers in the scene that defines a starting state for the layer if it was previously invisible. This allows controlling the animation from completely unrelated scenes where otherwise it would fly in the layer from the top left corner.

For example in the imagesource.yaml demo:
* when on the full-3 scene and moving back to the default scene the presentation view will zoom in from the center and the camera source will zoom in from the bottom right corner.
* If on full-2 or full-1 it will transition that source to the location in the default scene like before but use the warp starting position for the other source to make a smoother animation
* when switching between full-2 and full-3 the transition will now always be a fade because the warp puts the source in the center