### PR TITLE
Remove num_allocated_frames from example window sinks

### DIFF
--- a/examples/fazant.yaml
+++ b/examples/fazant.yaml
@@ -109,7 +109,6 @@ sinks:
     frames:
       width: 1280
       height: 720
-      num_allocated_frames: 5
     default_scene: foo
 
 api:

--- a/examples/fosdem.yaml
+++ b/examples/fosdem.yaml
@@ -136,7 +136,6 @@ sinks:
     frames:
       width: 1920
       height: 1080
-      num_allocated_frames: 5
     default_scene: presentation
   stream:
     type: ffmpeg_stdin


### PR DESCRIPTION
This causes:

    2025/07/19 13:04:32 sink projector is invalid: invalid frame config: number of allocated frames for window sinks must be 0