### PR TITLE
Window sink utility

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,9 @@ builddir:
 fazantix-wayland: builddir
 	go build -o build/fazantix -tags "wayland,vulkan" ./cmd/fazantix
 
+fazantix-window: builddir
+	go build -o build/fazantix-window ./cmd/fazantix-window
+
 run: fazantix
 	./build/fazantix $(CONFIG)
 

--- a/cmd/fazantix-window/main.go
+++ b/cmd/fazantix-window/main.go
@@ -1,0 +1,81 @@
+package main
+
+import (
+	"flag"
+	"log"
+	"runtime"
+
+	"github.com/fosdem/fazantix/lib/config"
+	"github.com/fosdem/fazantix/lib/encdec"
+	"github.com/fosdem/fazantix/lib/layer"
+	"github.com/fosdem/fazantix/lib/rendering"
+	"github.com/fosdem/fazantix/lib/rendering/shaders"
+	"github.com/fosdem/fazantix/lib/stdinsource"
+	"github.com/fosdem/fazantix/lib/utils"
+	"github.com/fosdem/fazantix/lib/windowsink"
+	"github.com/go-gl/glfw/v3.3/glfw"
+)
+
+func main() {
+
+	titlePtr := flag.String("title", "WindowSink", "Window title for this sink")
+	widthPtr := flag.Uint("width", 1920, "Width of the window sink")
+	heightPtr := flag.Uint("height", 1080, "Height of the window sink")
+	ratePtr := flag.Uint("rate", 60, "Framerate limiter on the input data")
+	flag.Parse()
+
+	width := int(*widthPtr)
+	height := int(*heightPtr)
+	rate := int(*ratePtr)
+	runtime.LockOSThread()
+	log.Printf("Accepting %dx%d@%d\n", width, height, rate)
+
+	alloc := &encdec.DumbFrameAllocator{}
+	err := rendering.Init()
+	if err != nil {
+		log.Fatalf("could not initialise renderer: %s", err)
+	}
+	sinkCfg := &config.WindowSinkCfg{}
+	frameCfg := &encdec.FrameCfg{
+		Width:              width,
+		Height:             height,
+		NumAllocatedFrames: 2,
+	}
+	windowSink := windowsink.New(*titlePtr, sinkCfg, frameCfg, alloc)
+	windowSink.Start()
+	stdinSource := stdinsource.New(width, height, rate, alloc)
+	sources := make([]layer.Source, 1)
+	sources[0] = stdinSource
+	stdinSource.Start()
+	shaderData := &shaders.ShaderData{
+		Sources:    sources,
+		NumSources: 1,
+	}
+	program, err := shaders.BuildGLProgram(shaderData)
+	if err != nil {
+		log.Fatalf("could not init GL program: %s", err)
+	}
+	glvars := rendering.NewGLVars(program, 1)
+
+	stage := &layer.Stage{
+		Layers:       make([]*layer.Layer, 1),
+		DefaultScene: "stdin",
+		Sink:         windowSink,
+	}
+	stage.Layers[0] = layer.New(stdinSource, width, height)
+	stage.Layers[0].Position.X = 0.0
+	stage.Layers[0].Position.Y = 0.0
+	stage.Layers[0].Opacity = 1
+	glvars.Start()
+	rendering.SetupTextures(stdinSource.Frames())
+
+	var deltaTimer utils.DeltaTimer
+	for {
+		glvars.StartFrame()
+		dt := deltaTimer.Next()
+		rendering.SendFramesToGPU(sources, dt)
+		glvars.DrawStage(stage)
+		windowSink.Window.SwapBuffers()
+		glfw.PollEvents()
+	}
+}

--- a/lib/encdec/encdec.go
+++ b/lib/encdec/encdec.go
@@ -149,6 +149,8 @@ func (f FrameType) String() string {
 		return "YUYV"
 	case RGBAFrames:
 		return "RGBA"
+	case RGBFrames:
+		return "RGB"
 	default:
 		panic("unknown frame type")
 	}

--- a/lib/encdec/frame_allocator.go
+++ b/lib/encdec/frame_allocator.go
@@ -1,6 +1,8 @@
 package encdec
 
-import "fmt"
+import (
+	"fmt"
+)
 
 type FrameCfg struct {
 	Width              int

--- a/lib/rendering/frame_transport.go
+++ b/lib/rendering/frame_transport.go
@@ -10,6 +10,9 @@ import (
 
 func SendFrameToGPU(frame *encdec.Frame, textureIDs [3]uint32, offset int) {
 	channelType := uint32(gl.RED)
+	if frame.Type == encdec.RGBFrames {
+		channelType = gl.RGB
+	}
 	if frame.Type == encdec.RGBAFrames || frame.Type == encdec.YUV422pFrames {
 		channelType = gl.RGBA
 	}

--- a/lib/rendering/shaders/composite.frag
+++ b/lib/rendering/shaders/composite.frag
@@ -62,6 +62,12 @@ vec4 sampleLayerRGBA(vec2 uv, int layer, vec4 dve, vec4 data) {
 	return col;
 }
 
+vec4 sampleLayerRGB(vec2 uv, int layer, vec4 dve, vec4 data) {
+	vec4 col = texture(tex[layer*3], (uv / dve.z) - (dve.xy / dve.zw));
+	col.a = 1.0;
+	return col;
+}
+
 void main() {
     vec2 uv = UV;
     if ((stageData & 1) != 0) {

--- a/lib/stdinsource/stdin_source.go
+++ b/lib/stdinsource/stdin_source.go
@@ -1,0 +1,75 @@
+package stdinsource
+
+import (
+	"bufio"
+	"io"
+	"os"
+	"time"
+
+	"github.com/fosdem/fazantix/lib/encdec"
+	"github.com/fosdem/fazantix/lib/layer"
+)
+
+type StdinSource struct {
+	Width     int
+	Height    int
+	Rate      int
+	frameSize int
+	frames    layer.FrameForwarder
+	reader    *bufio.Reader
+}
+
+func New(width, height, rate int, alloc encdec.FrameAllocator) *StdinSource {
+	f := &StdinSource{Width: width, Height: height, frameSize: width * height * 3}
+	frameCfg := &encdec.FrameCfg{
+		Width:              width,
+		Height:             height,
+		NumAllocatedFrames: 5,
+	}
+	f.Rate = rate
+	f.frames.Init(
+		"stdin",
+		&encdec.FrameInfo{
+			FrameType: encdec.RGBFrames,
+			PixFmt:    []uint8{},
+			FrameCfg:  *frameCfg,
+		},
+		alloc,
+	)
+	return f
+}
+
+func (f *StdinSource) Start() bool {
+	f.reader = bufio.NewReaderSize(os.Stdin, f.frameSize)
+	go f.processStdin()
+	return true
+}
+
+func (f *StdinSource) processStdin() {
+	ftime := time.Now()
+	frameTime := (1000000 / time.Duration(f.Rate)) * time.Microsecond
+	for {
+		frame := f.frames.GetFrameForWriting()
+		frame.Clear()
+		frame.MakeTexture(f.frameSize, f.Width, f.Height)
+		past := time.Since(ftime)
+		time.Sleep(frameTime - past)
+		ftime = time.Now()
+		_, err := io.ReadFull(f.reader, frame.Data)
+		if err != nil {
+			f.log("could not read from stdin: %s", err)
+			f.frames.FailedWriting(frame)
+			return
+		}
+
+		f.frames.FinishedWriting(frame)
+	}
+}
+
+func (f *StdinSource) Frames() *layer.FrameForwarder {
+	return &f.frames
+}
+
+func (f *StdinSource) log(msg string, args ...interface{}) {
+	f.Frames().Log(msg, args...)
+}


### PR DESCRIPTION
It is possible to use ffplay as ffmpegSink to spawn an extra window for a secondary stream. ffplay is not hardware accelerated though so this implements a small replacement for ffplay that can show a raw stream from stdin in RGB24 format in a window.