### PR TITLE
Small optimisations

### DIFF
--- a/lib/rendering/gl_vars.go
+++ b/lib/rendering/gl_vars.go
@@ -39,20 +39,19 @@ func NewGLVars(program uint32, numLayers int32) *GLVars {
 func (g *GLVars) Start() {
 	g.allocate()
 	gl.ClearColor(1.0, 0.0, 0.0, 1.0)
+	gl.UseProgram(g.Program)
+	gl.Uniform1iv(g.TexUniform, g.NumTextures, &g.Textures[0])
+
 }
 
 func (g *GLVars) StartFrame() {
-	gl.UseProgram(g.Program)
 	gl.BindVertexArray(g.VAO)
-	g.pushCommonVars()
 }
 
 func (g *GLVars) DrawStage(stage *layer.Stage) {
 	frames := stage.Sink.Frames()
 
 	gl.BindFramebuffer(gl.FRAMEBUFFER, frames.FramebufferID)
-	gl.Viewport(0, 0, int32(frames.Width), int32(frames.Height))
-	gl.Clear(gl.COLOR_BUFFER_BIT)
 
 	// push vars related to the window stage
 	g.readLayers(stage.Layers)
@@ -61,25 +60,10 @@ func (g *GLVars) DrawStage(stage *layer.Stage) {
 }
 
 func (g *GLVars) allocate() {
-	vertices := []float32{
-		//  X, Y,  U, V
-		-1.0, -1.0, 0.0, 1.0,
-		+1.0, -1.0, 1.0, 1.0,
-		+1.0, +1.0, 1.0, 0.0,
-
-		-1.0, -1.0, 0.0, 1.0,
-		+1.0, +1.0, 1.0, 0.0,
-		-1.0, +1.0, 0.0, 0.0,
-	}
 
 	// Configure the vertex data
 	gl.GenVertexArrays(1, &g.VAO)
 	gl.BindVertexArray(g.VAO)
-
-	gl.GenBuffers(1, &g.VBO)
-	gl.BindBuffer(gl.ARRAY_BUFFER, g.VBO)
-	gl.BufferData(gl.ARRAY_BUFFER, len(vertices)*f32, gl.Ptr(vertices), gl.STATIC_DRAW)
-
 	stride := int32(4 * f32)
 
 	vertAttrib := uint32(gl.GetAttribLocation(g.Program, gl.Str("position\x00")))
@@ -111,10 +95,6 @@ func (g *GLVars) allocate() {
 	gl.Uniform1iv(g.TexUniform, g.NumTextures, &g.Textures[0])
 }
 
-func (g *GLVars) pushCommonVars() {
-	gl.Uniform1iv(g.TexUniform, g.NumTextures, &g.Textures[0])
-}
-
 func (g *GLVars) readLayers(layers []*layer.Layer) {
 	for i := range g.NumLayers {
 		g.LayerPos[(i*4)+0] = layers[i].Position.X
@@ -131,5 +111,5 @@ func (g *GLVars) pushStageVars() {
 	gl.Uniform4fv(g.LayerPosUniform, g.NumLayers, &g.LayerPos[0])
 
 	// draw vertices on the window stage
-	gl.DrawArrays(gl.TRIANGLES, 0, 2*3)
+	gl.DrawArrays(gl.TRIANGLES, 0, 1*3)
 }

--- a/lib/rendering/init.go
+++ b/lib/rendering/init.go
@@ -2,7 +2,6 @@ package rendering
 
 import (
 	"fmt"
-	"log"
 
 	"github.com/go-gl/gl/v4.1-core/gl"
 )
@@ -12,9 +11,5 @@ func Init() error {
 	if err != nil {
 		return fmt.Errorf("could not initialise OpenGL context: %w", err)
 	}
-
-	version := gl.GoStr(gl.GetString(gl.VERSION))
-	log.Printf("OpenGL version '%s'", version)
-
 	return nil
 }

--- a/lib/rendering/shaders/composite.frag
+++ b/lib/rendering/shaders/composite.frag
@@ -4,7 +4,6 @@ in vec2 UV;
 
 out vec4 color;
 
-uniform uint stageData;
 uniform sampler2D tex[{{ .NumSources }} * 3];
 uniform vec4 layerPosition[{{ .NumSources }}];
 uniform vec4 layerData[{{ .NumSources }}];
@@ -63,16 +62,9 @@ vec4 sampleLayerRGBA(vec2 uv, int layer, vec4 dve, vec4 data) {
 }
 
 void main() {
-    vec2 uv = UV;
-    if ((stageData & 1) != 0) {
-        uv = vec2(uv.x, 1-uv.y);
-    }
-    if ((stageData & 2) != 0) {
-        uv = vec2(1-uv.x, uv.y);
-    }
     vec4 composite;
     {{ range $i, $source := .Sources }}
-        vec4 layer_{{ $i }} = sampleLayer{{ $source.Frames.FrameType.String }}(uv, {{ $i }}, layerPosition[{{ $i }}], layerData[{{ $i }}]);
+        vec4 layer_{{ $i }} = sampleLayer{{ $source.Frames.FrameType.String }}(UV, {{ $i }}, layerPosition[{{ $i }}], layerData[{{ $i }}]);
 
         {{ if eq $i 0 }}
             composite = layer_{{ $i }};

--- a/lib/rendering/shaders/screen.vert
+++ b/lib/rendering/shaders/screen.vert
@@ -1,11 +1,11 @@
 #version 400
 
-in vec2 position;
-in vec2 uv;
-
 out vec2 UV;
 
 void main() {
-    gl_Position = vec4(position, 0.0, 1.0);
-    UV = uv;
+    // Generate a single triangle that fits the entire viewport and
+    // give it UV coordinates that make 0.0-1.0 fall inside the viewport
+    vec2 vertices[3]=vec2[3](vec2(-1,-1), vec2(3,-1), vec2(-1, 3));
+    gl_Position = vec4(vertices[gl_VertexID],0,1);
+    UV = vec2(0.5, -0.5) * gl_Position.xy + vec2(0.5);
 }

--- a/lib/rendering/shaders/screen.vert
+++ b/lib/rendering/shaders/screen.vert
@@ -1,11 +1,20 @@
 #version 400
 
 out vec2 UV;
+uniform uint stageData;
 
 void main() {
+    vec2 orientation=vec2(0.5, -0.5);
+    if ((stageData & 1) != 0) {
+        orientation.y = 0.5;
+    }
+    if ((stageData & 2) != 0) {
+        orientation.x = -0.5;
+    }
+
     // Generate a single triangle that fits the entire viewport and
     // give it UV coordinates that make 0.0-1.0 fall inside the viewport
     vec2 vertices[3]=vec2[3](vec2(-1,-1), vec2(3,-1), vec2(-1, 3));
     gl_Position = vec4(vertices[gl_VertexID],0,1);
-    UV = vec2(0.5, -0.5) * gl_Position.xy + vec2(0.5);
+    UV = orientation * gl_Position.xy + vec2(0.5);
 }

--- a/lib/windowsink/window_sink.go
+++ b/lib/windowsink/window_sink.go
@@ -6,6 +6,7 @@ import (
 	"github.com/fosdem/fazantix/lib/config"
 	"github.com/fosdem/fazantix/lib/encdec"
 	"github.com/fosdem/fazantix/lib/layer"
+	"github.com/go-gl/gl/v4.1-core/gl"
 	"github.com/go-gl/glfw/v3.3/glfw"
 )
 
@@ -40,7 +41,7 @@ func (w *WindowSink) Frames() *layer.FrameForwarder {
 }
 
 func (w *WindowSink) makeWindow() *glfw.Window {
-	log.Println("Initializing window")
+	w.log("Initializing window")
 	if err := glfw.Init(); err != nil {
 		log.Fatalln("failed to initialize glfw:", err)
 	}
@@ -57,5 +58,15 @@ func (w *WindowSink) makeWindow() *glfw.Window {
 
 	window.MakeContextCurrent()
 
+	vendor := gl.GoStr(gl.GetString(gl.VENDOR))
+	renderer := gl.GoStr(gl.GetString(gl.RENDERER))
+	version := gl.GoStr(gl.GetString(gl.VERSION))
+
+	w.log("OpenGL version %s / %s / %s", vendor, renderer, version)
+
 	return window
+}
+
+func (w *WindowSink) log(msg string, args ...interface{}) {
+	w.Frames().Log(msg, args...)
 }


### PR DESCRIPTION
* Render to a big triangle instead of a fullscreen quad. This saves overdraw on the diagonal line because the fragment shader works on blocks of pixels and will discard results outside the current face.
* Basically all opengl state is saved between frames so don't try to update the state on every frame or stage when it doesn't need to change since that makes openGL unhappy
* Make the vertex shader generate the triangle instead of pushing a vertex buffer
* Move the orientation calculation to the vertex shader so it isn't calculated for every fragment but only 3 times per frame.
* Stop calling gl.GetString before the context is created