### PR TITLE
Use RGBA instead of RGB for the extra framebuffers

### DIFF
--- a/examples/fosdem.yaml
+++ b/examples/fosdem.yaml
@@ -139,7 +139,7 @@ sinks:
     default_scene: presentation
   stream:
     type: ffmpeg_stdin
-    cmd: "ffmpeg -f rawvideo -video_size 1280x720 -pixel_format rgb24 -framerate 60 -i - -c:v libx264 -preset fast -pix_fmt yuv420p -f mpegts tcp://0.0.0.0:2000?listen"
+    cmd: "ffmpeg -f rawvideo -video_size 1280x720 -pixel_format rgba -framerate 60 -i - -c:v libx264 -preset fast -pix_fmt yuv420p -f mpegts tcp://0.0.0.0:2000?listen"
     frames:
       width: 1280
       height: 720

--- a/lib/ffmpegsink/ffmpeg_sink.go
+++ b/lib/ffmpegsink/ffmpeg_sink.go
@@ -28,7 +28,7 @@ func New(name string, cfg *config.FFmpegSinkCfg, frameCfg *encdec.FrameCfg, allo
 	f.frames.Init(
 		name,
 		&encdec.FrameInfo{
-			FrameType: encdec.RGBFrames,
+			FrameType: encdec.RGBAFrames,
 			FrameCfg:  *frameCfg,
 		},
 		alloc,

--- a/lib/rendering/frame_transport.go
+++ b/lib/rendering/frame_transport.go
@@ -28,7 +28,7 @@ func SendFrameToGPU(frame *encdec.Frame, textureIDs [3]uint32, offset int) {
 }
 
 func GetFrameFromGPU(frame *encdec.Frame) {
-	gl.ReadPixels(0, 0, int32(frame.Width), int32(frame.Height), gl.RGB, gl.UNSIGNED_BYTE, gl.Ptr(frame.Data))
+	gl.ReadPixels(0, 0, int32(frame.Width), int32(frame.Height), gl.RGBA, gl.UNSIGNED_BYTE, gl.Ptr(frame.Data))
 }
 
 type ThingWithFrames interface {

--- a/lib/rendering/textures.go
+++ b/lib/rendering/textures.go
@@ -29,8 +29,8 @@ func SetupTextures(f *layer.FrameForwarder) {
 }
 
 func UseAsFramebuffer(f *layer.FrameForwarder) {
-	if f.FrameType != encdec.RGBFrames {
-		panic("trying to use a non-rgb frame forwarder as a framebuffer")
+	if f.FrameType != encdec.RGBAFrames {
+		panic("trying to use a non-rgba frame forwarder as a framebuffer")
 	}
 	f.FramebufferID = UseTextureAsFramebuffer(f.TextureIDs[0])
 }


### PR DESCRIPTION
Using RGBA uses a bit more bandwidth but it skips format conversion on the GPU making the result faster. Gives a 37% performance improvement on my laptop