### PR TITLE
Support creating imagesource instances without a file

### DIFF
--- a/lib/config/config.go
+++ b/lib/config/config.go
@@ -155,6 +155,8 @@ type WindowSinkCfg struct {
 
 type ImgSourceCfg struct {
 	Path    CfgPath
+	Width   int
+	Height  int
 	Inotify bool
 }
 
@@ -235,7 +237,16 @@ func (s *SourceCfg) Validate() error {
 
 func (s *ImgSourceCfg) Validate() error {
 	if s.Path == "" {
-		return fmt.Errorf("image path must be specified")
+		if s.Width == 0 && s.Height == 0 {
+			return fmt.Errorf("image path or size must be specified")
+		}
+		if s.Inotify {
+			return fmt.Errorf("cannot enable inotify for an imagesource without path")
+		}
+	} else {
+		if s.Width != 0 || s.Height != 0 {
+			return fmt.Errorf("image path or size can't both be specified")
+		}
 	}
 	return nil
 }

--- a/lib/imgsource/imgsource.go
+++ b/lib/imgsource/imgsource.go
@@ -29,9 +29,13 @@ func New(name string, cfg *config.ImgSourceCfg, alloc encdec.FrameAllocator) *Im
 	s.frames.Name = name
 	s.inotify = cfg.Inotify
 
-	err := s.LoadImage(string(cfg.Path))
-	if err != nil {
-		return nil
+	if cfg.Path != "" {
+		err := s.LoadImage(string(cfg.Path))
+		if err != nil {
+			return nil
+		}
+	} else {
+		s.CreateImage(cfg.Width, cfg.Height)
 	}
 	s.frames.Init(
 		name,
@@ -142,6 +146,17 @@ func (s *ImgSource) LoadImage(newPath string) error {
 
 	s.rgba = image.NewNRGBA(s.img.Bounds())
 	return nil
+}
+
+func (s *ImgSource) CreateImage(width, height int) {
+	s.img = image.NewNRGBA(image.Rectangle{
+		Min: image.Point{},
+		Max: image.Point{
+			X: width,
+			Y: height,
+		},
+	})
+	s.rgba = s.img.(*image.NRGBA)
 }
 
 func (s *ImgSource) SetImage(newImage image.Image) error {


### PR DESCRIPTION
For in-memory images like the multiview overlay, but also allows to load a file later through the API