### PR TITLE
Implement USB locator

### DIFF
--- a/lib/utils/usb_locator.go
+++ b/lib/utils/usb_locator.go
@@ -1,0 +1,83 @@
+package utils
+
+import (
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+type DeviceType int
+
+const (
+	V4L2Device DeviceType = iota
+	MediaDevice
+)
+
+type USBDevice struct {
+	Type DeviceType
+	Path string
+}
+type USBDeviceCollection struct {
+	Devices []*USBDevice
+}
+
+func (c USBDeviceCollection) GetFirst(devType DeviceType) *USBDevice {
+	sort.Slice(c.Devices, func(i, j int) bool {
+		return c.Devices[i].Path < c.Devices[j].Path
+	})
+	for _, dev := range c.Devices {
+		if dev.Type == devType {
+			return dev
+		}
+	}
+	return nil
+}
+
+func LocateUSBDevice(port string) (*USBDeviceCollection, error) {
+	dir := filepath.Join("/sys/bus/usb/devices", port)
+	items, err := os.ReadDir(dir)
+	if err != nil {
+		return nil, err
+	}
+
+	result := &USBDeviceCollection{make([]*USBDevice, 0)}
+
+	for _, item := range items {
+		if !item.IsDir() {
+			continue
+		}
+		// Skip everything that's not an interface
+		if !strings.Contains(item.Name(), ":") {
+			continue
+		}
+
+		drivers, err := os.ReadDir(filepath.Join(dir, item.Name()))
+		if err != nil {
+			continue
+		}
+		for _, driver := range drivers {
+			if driver.Name() == "video4linux" {
+				subdirs, err := os.ReadDir(filepath.Join(dir, item.Name(), "video4linux"))
+				if err != nil {
+					continue
+				}
+				for _, subdir := range subdirs {
+					if strings.HasPrefix(subdir.Name(), "video") {
+						result.Devices = append(result.Devices, &USBDevice{
+							Type: V4L2Device,
+							Path: filepath.Join("/dev", subdir.Name()),
+						})
+					}
+				}
+			}
+			if strings.HasPrefix(driver.Name(), "media") {
+				result.Devices = append(result.Devices, &USBDevice{
+					Type: MediaDevice,
+					Path: filepath.Join("/dev", driver.Name()),
+				})
+			}
+		}
+	}
+	return result, nil
+}

--- a/lib/v4lsource/v4lsource.go
+++ b/lib/v4lsource/v4lsource.go
@@ -14,6 +14,7 @@ import (
 	"github.com/fosdem/fazantix/lib/config"
 	"github.com/fosdem/fazantix/lib/encdec"
 	"github.com/fosdem/fazantix/lib/layer"
+	"github.com/fosdem/fazantix/lib/utils"
 )
 
 type V4LSource struct {
@@ -56,6 +57,20 @@ func (s *V4LSource) Start() bool {
 
 	s.log("Loading v4l2 device %s", s.path)
 
+	if !strings.HasPrefix(s.path, "/") {
+		lookup, err := utils.LocateUSBDevice(s.path)
+		if err != nil {
+			s.log("Failed to find device: %s", err)
+			return false
+		}
+		v4l2dev := lookup.GetFirst(utils.V4L2Device)
+		if v4l2dev == nil {
+			s.log("USB device in port %s does not have a V4L2 driver", s.path)
+			return false
+		}
+		s.log("Found V4L2 device %s at port %s", v4l2dev.Path, s.path)
+		s.path = v4l2dev.Path
+	}
 	camera, err := device.Open(
 		s.path,
 		device.WithPixFormat(v4l2.PixFormat{


### PR DESCRIPTION
Add an utility function for getting the devices from an USB port number, for now support V4L2 devices and V4L2-media devices. For example when I have a hagibis on usb port 2-3 on my laptop it returns this:

```go
devices, _ := utils.LocateUSBDevice("2-3")
devices.GetFirst(utils.V4L2Device) // returns /dev/video0
devices.GetFirst(utils.MediaDevice) // returns /dev/media0
```

This is required for supporting restarting the source when an USB device is unplugged since that might give it a random other video device number because there's still handles open on the old one.