### PR TITLE
Support streaming a stage as OMT sender

### DIFF
--- a/lib/config/config.go
+++ b/lib/config/config.go
@@ -151,6 +151,10 @@ type FFmpegSinkCfg struct {
 	Cmd string
 }
 
+type OmtSinkCfg struct {
+	Name string
+}
+
 type WindowSinkCfg struct {
 }
 
@@ -201,6 +205,10 @@ func (s *StageCfg) UnmarshalYAML(b []byte) error {
 	switch s.Type {
 	case "ffmpeg_stdin":
 		cfg := FFmpegSinkCfg{}
+		s.SinkCfg = &cfg
+		return yaml.Unmarshal(b, &cfg)
+	case "omt":
+		cfg := OmtSinkCfg{}
 		s.SinkCfg = &cfg
 		return yaml.Unmarshal(b, &cfg)
 	case "window":
@@ -269,6 +277,13 @@ func (s *FFmpegSourceCfg) Validate() error {
 func (s *FFmpegSinkCfg) Validate() error {
 	if s.Cmd == "" {
 		return fmt.Errorf("ffmpeg cmd must be specified")
+	}
+	return nil
+}
+
+func (s *OmtSinkCfg) Validate() error {
+	if s.Name == "" {
+		return fmt.Errorf("OMT sink name must be specified")
 	}
 	return nil
 }

--- a/lib/encdec/encdec.go
+++ b/lib/encdec/encdec.go
@@ -14,6 +14,7 @@ const (
 	YUV422Frames FrameType = iota
 	YUV422pFrames
 	RGBAFrames
+	BGRAFrames
 	RGBFrames
 )
 

--- a/lib/encdec/frame_allocator.go
+++ b/lib/encdec/frame_allocator.go
@@ -120,6 +120,8 @@ func calcFrameSize(info *FrameInfo) (int, int, int) {
 	case YUV422pFrames:
 		return w * h * 2, w, h
 	case RGBAFrames:
+		fallthrough
+	case BGRAFrames:
 		return w * h * 4, w, h
 	case RGBFrames:
 		return w * h * 3, w, h

--- a/lib/rendering/frame_transport.go
+++ b/lib/rendering/frame_transport.go
@@ -28,7 +28,16 @@ func SendFrameToGPU(frame *encdec.Frame, textureIDs [3]uint32, offset int) {
 }
 
 func GetFrameFromGPU(frame *encdec.Frame) {
-	gl.ReadPixels(0, 0, int32(frame.Width), int32(frame.Height), gl.RGBA, gl.UNSIGNED_BYTE, gl.Ptr(frame.Data))
+	packing := uint32(0)
+	switch frame.Type {
+	case encdec.RGBAFrames:
+		packing = gl.RGBA
+	case encdec.BGRAFrames:
+		packing = gl.BGRA
+	default:
+		panic("Unsupported packing for ReadPixels")
+	}
+	gl.ReadPixels(0, 0, int32(frame.Width), int32(frame.Height), packing, gl.UNSIGNED_BYTE, gl.Ptr(frame.Data))
 }
 
 type ThingWithFrames interface {

--- a/lib/rendering/textures.go
+++ b/lib/rendering/textures.go
@@ -20,16 +20,20 @@ func SetupTextures(f *layer.FrameForwarder) {
 		f.TextureIDs[1] = SetupYUVTexture(width/2, height)
 		f.TextureIDs[2] = SetupYUVTexture(width/2, height)
 	case encdec.RGBAFrames:
-		f.TextureIDs[0] = SetupRGBATexture(width, height)
+		f.TextureIDs[0] = SetupRGBATexture(width, height, gl.RGBA)
+	case encdec.BGRAFrames:
+		f.TextureIDs[0] = SetupRGBATexture(width, height, gl.BGRA)
 	case encdec.YUV422pFrames:
-		f.TextureIDs[0] = SetupRGBATexture(width/2, height)
+		f.TextureIDs[0] = SetupRGBATexture(width/2, height, gl.RGBA)
 	case encdec.RGBFrames:
 		f.TextureIDs[0] = SetupRGBTexture(width, height)
+	default:
+		panic("Unknown pixel format")
 	}
 }
 
 func UseAsFramebuffer(f *layer.FrameForwarder) {
-	if f.FrameType != encdec.RGBAFrames {
+	if f.FrameType != encdec.RGBAFrames && f.FrameType != encdec.BGRAFrames {
 		panic("trying to use a non-rgba frame forwarder as a framebuffer")
 	}
 	f.FramebufferID = UseTextureAsFramebuffer(f.TextureIDs[0])
@@ -62,7 +66,7 @@ func SetupYUVTexture(width int, height int) uint32 {
 	return id
 }
 
-func SetupRGBATexture(width int, height int) uint32 {
+func SetupRGBATexture(width int, height int, packing uint32) uint32 {
 	var id uint32
 	gl.GenTextures(1, &id)
 	gl.ActiveTexture(gl.TEXTURE0)
@@ -82,7 +86,7 @@ func SetupRGBATexture(width int, height int) uint32 {
 		int32(width),
 		int32(height),
 		0,
-		gl.RGBA,
+		packing,
 		gl.UNSIGNED_BYTE,
 		gl.Ptr(&buf[0]),
 	)

--- a/lib/sink/omtsink/libomt/libomt.go
+++ b/lib/sink/omtsink/libomt/libomt.go
@@ -1,0 +1,123 @@
+package libomt
+
+/*
+#cgo pkg-config: libomt
+#include "libomt.h"
+#include "string.h"
+*/
+import "C"
+import (
+	"fmt"
+	"unsafe"
+)
+
+type OmtSend struct {
+	send *C.omt_send_t
+	mf   *C.OMTMediaFrame
+}
+
+func OmtSendCreate(name string, quality Quality) (*OmtSend, error) {
+	result := &OmtSend{}
+	nameStr := C.CString(name)
+	result.send = C.omt_send_create(nameStr, C.OMTQuality(quality))
+	if result.send == nil {
+		return nil, fmt.Errorf("failed to create OmtSend")
+	}
+	return result, nil
+}
+
+func (s *OmtSend) Send(frame *OmtMediaFrame, data []byte) int {
+	if s.mf == nil {
+		s.mf = &C.OMTMediaFrame{}
+		s.mf.Data = C.malloc(C.size_t(len(data)))
+		s.mf.Timestamp = C.int64_t(frame.Timestamp)
+	}
+	s.mf.Type = C.OMTFrameType_Video
+	s.mf.Codec = uint32(frame.Codec)
+	s.mf.Width = C.int(frame.Width)
+	s.mf.Height = C.int(frame.Height)
+	s.mf.Stride = C.int(frame.Stride)
+	s.mf.Flags = uint32(frame.Flags)
+	s.mf.FrameRateN = C.int(frame.FrameRateN)
+	s.mf.FrameRateD = C.int(frame.FrameRateD)
+	s.mf.AspectRatio = C.float(frame.AspectRatio)
+	s.mf.ColorSpace = uint32(frame.ColorSpace)
+
+	s.mf.DataLength = C.int(len(data))
+	C.memcpy(s.mf.Data, unsafe.Pointer(&data[0]), C.size_t(len(data)))
+
+	C.omt_send(s.send, s.mf)
+	return 0
+}
+
+type FrameType int
+
+const (
+	None     FrameType = iota
+	Metadata           = iota
+	Video              = iota
+	Audio              = iota
+)
+
+type Quality int32
+
+const (
+	QualityDefault Quality = C.OMTQuality_Default
+	QualityLow             = C.OMTQuality_Low
+	QualityMedium          = C.OMTQuality_Medium
+	QualityHigh            = C.OMTQuality_High
+)
+
+type Codec int
+
+const (
+	CodecVMX1 Codec = C.OMTCodec_VMX1
+	CodecFPA1       = C.OMTCodec_FPA1
+	CodecBGRA       = C.OMTCodec_BGRA
+	CodecUYVY       = C.OMTCodec_UYVY
+	CodecYUY2       = C.OMTCodec_YUY2
+	CodecNV12       = C.OMTCodec_NV12
+	CodecYV12       = C.OMTCodec_YV12
+	CodecUYVA       = C.OMTCodec_UYVA
+	CodecP216       = C.OMTCodec_P216
+	CodecPA16       = C.OMTCodec_PA16
+)
+
+type ColorSpace int
+
+const (
+	ColorSpaceUndefined ColorSpace = C.OMTColorSpace_Undefined
+	ColorSpaceBT601     ColorSpace = C.OMTColorSpace_BT601
+	ColorSpaceBT709     ColorSpace = C.OMTColorSpace_BT709
+)
+
+type VideoFlags int
+
+const (
+	VideoFlagsNone          VideoFlags = 0
+	VideoFlagsInterlaced               = 1
+	VideoFlagsAlpha                    = 2
+	VideoFlagsPreMultiplied            = 4
+	VideoFlagsPreview                  = 4
+	VideoFlagsHighBitDepth             = 16
+)
+
+type OmtMediaFrame struct {
+	Width         int
+	Height        int
+	Codec         Codec
+	Timestamp     int64
+	ColorSpace    ColorSpace
+	Flags         VideoFlags
+	Stride        int
+	DataLength    int
+	FrameRateN    int
+	FrameRateD    int
+	AspectRatio   float32
+	FrameMetadata []byte
+
+	// Audio properties
+	SampleRate        int
+	Channels          int
+	SamplesPerChannel int
+}

--- a/lib/theatre/theatre.go
+++ b/lib/theatre/theatre.go
@@ -11,6 +11,7 @@ import (
 	"github.com/fosdem/fazantix/lib/rendering"
 	"github.com/fosdem/fazantix/lib/rendering/shaders"
 	"github.com/fosdem/fazantix/lib/sink/ffmpegsink"
+	"github.com/fosdem/fazantix/lib/sink/omtsink"
 	"github.com/fosdem/fazantix/lib/sink/windowsink"
 	"github.com/fosdem/fazantix/lib/source/ffmpegsource"
 	"github.com/fosdem/fazantix/lib/source/imgsource"
@@ -88,6 +89,8 @@ func buildStageMap(cfg *config.Config, sources []layer.Source, alloc encdec.Fram
 			stage.Sink = ffmpegsink.New(stageName, sc, &stageCfg.FrameCfg, alloc)
 		case *config.WindowSinkCfg:
 			stage.Sink = windowsink.New(stageName, sc, &stageCfg.FrameCfg, alloc)
+		case *config.OmtSinkCfg:
+			stage.Sink = omtsink.New(stageName, sc, &stageCfg.FrameCfg, alloc)
 		default:
 			panic(fmt.Sprintf("unhandled sink type: %+v", stageCfg.SinkCfg))
 		}


### PR DESCRIPTION
Use libomt to implement an OMT sender which encodes the video with libvmx (a low latency codec) and transmit it using the Open Media Transport protocol.

To build run through the libomtnet installation steps first and also add this pkg-config file:

```pkg-config
prefix=/usr
includedir=${prefix}/include
libdir=${prefix}/lib

Name: libomt
Description: Tools to deal with kernel modules
Version: 0.1
Cflags: -I${includedir}
Libs: -L${libdir} -lomt
```