### PR TITLE
Fix build of the OMT sink after the frameforwarder changes

### DIFF
--- a/lib/sink/omtsink/omt_sink.go
+++ b/lib/sink/omtsink/omt_sink.go
@@ -82,7 +82,7 @@ func (f *OmtSink) Start() bool {
 func (f *OmtSink) sendFrames() {
 	interval := time.Now()
 	for {
-		frame := f.Frames().GetFrameForReading()
+		frame := f.Frames().GetFreshFrameForReading()
 		if frame == nil {
 			continue
 		}


### PR DESCRIPTION
Can't build with the OMT tag enabled because this api change